### PR TITLE
Rename default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - development
 language: python
 python:
 - '3.4'


### PR DESCRIPTION
Change default branch name from `master` to `development`.

Please note that this is also the first pull request to use `Squash & Merge` instead of `Rebase & Merge`. Branch protection on `development` has also been enabled.