### PR TITLE
Integrate tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,32 @@ python:
 - '3.4'
 - '3.5'
 env:
-- DJANGO_VERSION=">=1.8,<1.9"
-- DJANGO_VERSION=">=1.9,<1.10"
-- DJANGO_VERSION=">=1.10,<1.11"
-- DJANGO_VERSION=">=1.11,<1.12"
+- DJANGO_VERSION="django>=1.8,<1.9"
+- DJANGO_VERSION="django>=1.10,<1.11"
+- DJANGO_VERSION="django>=1.11,<1.12"
 matrix:
   include:
+    - python: 3.5
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
     - python: 3.6
-      env: DJANGO_VERSION=">=1.11,<1.12"
+      env: DJANGO_VERSION="django>=1.11,<1.12"
+    - python: 3.6
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
     - python: '3.7-dev'
-      env: DJANGO_VERSION=">=1.11,<1.12"
+      env: DJANGO_VERSION="django>=1.11,<1.12"
+    - python: '3.7-dev'
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
   allow_failures:
+    - python: 3.5
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
+    - python: 3.6
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
     - python: '3.7-dev'
-      env: DJANGO_VERSION=">=1.11,<1.12"
+      env: DJANGO_VERSION="django>=1.11,<1.12"
+    - python: '3.7-dev'
+      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
 install:
   - "pip install -r requirements.txt"
-  - "pip install django$DJANGO_VERSION"
+  - "pip install $DJANGO_VERSION"
 script:
   - "./setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,37 @@
 branches:
   only:
-    - development
+  - development
 language: python
 python:
-- '3.4'
-- '3.5'
+- 3.4
+- 3.5
 env:
-- DJANGO_VERSION="django>=1.8,<1.9"
-- DJANGO_VERSION="django>=1.10,<1.11"
-- DJANGO_VERSION="django>=1.11,<1.12"
+- DJANGO=django>=1.8,<1.9
+- DJANGO=django>=1.10,<1.11
+- DJANGO=django>=1.11,<1.12
 matrix:
   include:
-    - python: 3.5
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
-    - python: 3.6
-      env: DJANGO_VERSION="django>=1.11,<1.12"
-    - python: 3.6
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
-    - python: '3.7-dev'
-      env: DJANGO_VERSION="django>=1.11,<1.12"
-    - python: '3.7-dev'
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
+  - python: 3.5
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
+  - python: 3.6
+    env: DJANGO=django>=1.11,<1.12
+  - python: 3.6
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
+  - python: 3.7-dev
+    env: DJANGO=django>=1.11,<1.12
+  - python: 3.7-dev
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
   allow_failures:
-    - python: 3.5
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
-    - python: 3.6
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
-    - python: '3.7-dev'
-      env: DJANGO_VERSION="django>=1.11,<1.12"
-    - python: '3.7-dev'
-      env: DJANGO_VERSION="https://github.com/django/django/archive/master.tar.gz"
+  - python: 3.5
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
+  - python: 3.6
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
+  - python: 3.7-dev
+    env: DJANGO=django>=1.11,<1.12
+  - python: 3.7-dev
+    env: DJANGO=https://github.com/django/django/archive/master.tar.gz
 install:
-  - "pip install -r requirements.txt"
-  - "pip install $DJANGO_VERSION"
+- pip install -r requirements.txt
+- pip install $DJANGO
 script:
-  - "./setup.py test"
+- ./setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 setuptools==36.2.4
+tox==2.7.0
 twine==1.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+       {py34,py35}-django{18,110}
+       {py34,py35,py36}-django111,
+       {py35,py36}-djangomaster
+
+[testenv]
+commands = ./runtests.py
+setenv =
+       PYTHONDONTWRITEBYTECODE=1
+       PYTHONWARNINGS=once
+deps =
+        django18: Django>=1.8,<1.9
+        django110: Django>=1.10,<1.11
+        django111: Django>=1.11,<2.0
+        djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Use tox to test the package against multiple Django versions and multiple Python versions. Include the nightly version of Django.

Update TravisCI config to forego Django 1.9 (no longer supported), but to test on Django nightly as well.

Travis tests against Python 3.7 (development) as well. The task of installing Python development is onerous, and so we do not include it in tox.