### PR TITLE
Integrate Django tests into project

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = False
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -151,7 +151,7 @@ inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 method-name-hint=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
-method-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
+method-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*)|(test_[a-z0-9_]*)|setUpTestData)$
 
 # Naming hint for module names
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
 - if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then check-manifest . ; fi
 - if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then flake8 src tests setup.py runtests.py ; fi
 - if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then isort --verbose --check-only --diff --recursive src tests setup.py runtests.py ; fi
-- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then pylint --rcfile=.pylintrc -d fixme src setup.py runtests.py ; fi
+- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then pylint --rcfile=.pylintrc -d fixme src tests setup.py runtests.py ; fi
 script:
 # do not use setup.py test with coverage; missing files omitted entirely
 - coverage run runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ after_success:
 # coverage is run in parallel, so it is necessary to combine the reports
 # Note that this is only for our benefit: codecov handles this itself
 # https://github.com/codecov/codecov-python/issues/72
-- coverage combine --append && coverage report && coverage html && codecov
+- coverage combine --append && coverage report && codecov
 after_script:
 - pip uninstall -y django  # to remove from cache

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,25 +5,30 @@ History
 Next Release
 ------------
 
+- Nothing yet!
+
+0.3.0 (2017-08-10)
+------------------
+
 - Integrate coverage and codecov service (PR `#16`_)
 - Make TravisCI test builds public (first seen in PR `#16`_)
 - Merge appropriate tests from Django master (1.11.3 is current release
   at time of writing). This increases test coverage across the board and
   updates the test suite to check for parity between Django's User API
   and Improved User's API as well as check for the same security issues.
-  (PR `18_`)
+  (PR `#18_`)
 - UserManager raises a friendly error if the developer tries to pass a
-  username argument (PR `18_`)
+  username argument (PR `#18_`)
 - Password errors are shown above both password fields
-  (PR `18_`)
+  (PR `#18_`)
 - Bugfix: UserManager handles is_staff, is_active, and is_superuser
-  correctly (PR `18_`)
-- Bugfix: User has email normalized during Model.clean phase (PR `18_`)
+  correctly (PR `#18_`)
+- Bugfix: User has email normalized during Model.clean phase (PR `#18_`)
 - Bugfix: UserAdmin requires short_name in both add and change
-  (previously only in change; PR `18_`)
+  (previously only in change; PR `#18_`)
 - Bugfix: UserAdmin uses correct relative path URL for password change
-  in all versions of Django (was not working in Django 1.9+) (PR `18_`)
-- Bugfix: Runtests correctly handles test specification (PR `18_`)
+  in all versions of Django (was not working in Django 1.9+) (PR `#18_`)
+- Bugfix: Runtests correctly handles test specification (PR `#18_`)
 
 .. _#16: https://github.com/jambonsw/django-improved-user/pull/16
 .. _#18: https://github.com/jambonsw/django-improved-user/pull/18

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,8 +23,7 @@ Next Release
   (previously only in change; PR `18_`)
 - Bugfix: UserAdmin uses correct relative path URL for password change
   in all versions of Django (was not working in Django 1.9+) (PR `18_`)
-- Bugfix: Runtests correctly handles test specification, e.g.:
-  ``$ ./runtests tests.test_basic`` (PR `18_`)
+- Bugfix: Runtests correctly handles test specification (PR `18_`)
 
 .. _#16: https://github.com/jambonsw/django-improved-user/pull/16
 .. _#18: https://github.com/jambonsw/django-improved-user/pull/18
@@ -32,19 +31,19 @@ Next Release
 0.2.0 (2017-07-30)
 ------------------
 
-    - Reorganize project to follow best practices (PR `#9`_)
-    - Allow setup.py to run tests by overriding test command (PR `#9`_)
-    - Test locally with Tox (PR `#10`_)
-    - Remove Django 1.9 from supported versions (PR `#10`_)
-    - Enforce styleguide with flake8, isort, and pylint.
-      Use flake8-commas and flake8-quotes to enhance flake8.
-      Override default distutils check command to check package metadata.
-      Use check-manifest to check contents of MANIFEST.in (PR `#11`_)
-    - Integrate https://pyup.io/ into project (PR `#12`_)
-    - Upgrade flake8 to version 3.4.1 (PR `#13`_)
-    - Make release and distribution less painful with
-      bumpversion package and a Makefile (PR `#15`_)
-    - Add HISTORY.rst file to provide change log (PR `#15`_)
+- Reorganize project to follow best practices (PR `#9`_)
+- Allow setup.py to run tests by overriding test command (PR `#9`_)
+- Test locally with Tox (PR `#10`_)
+- Remove Django 1.9 from supported versions (PR `#10`_)
+- Enforce styleguide with flake8, isort, and pylint.
+  Use flake8-commas and flake8-quotes to enhance flake8.
+  Override default distutils check command to check package metadata.
+  Use check-manifest to check contents of MANIFEST.in (PR `#11`_)
+- Integrate https://pyup.io/ into project (PR `#12`_)
+- Upgrade flake8 to version 3.4.1 (PR `#13`_)
+- Make release and distribution less painful with
+  bumpversion package and a Makefile (PR `#15`_)
+- Add HISTORY.rst file to provide change log (PR `#15`_)
 
 .. _#9: https://github.com/jambonsw/django-improved-user/pull/9
 .. _#10: https://github.com/jambonsw/django-improved-user/pull/10
@@ -56,22 +55,22 @@ Next Release
 0.1.1 (2017-06-28)
 ------------------
 
-    - Fix metadata in setup.py for warehouse
-      (see https://github.com/pypa/warehouse/issues/2155 and PR `#8`_)
+- Fix metadata in setup.py for warehouse
+  (see https://github.com/pypa/warehouse/issues/2155 and PR `#8`_)
 
 .. _#8: https://github.com/jambonsw/django-improved-user/pull/8
 
 0.1.0 (2017-06-28)
 ------------------
 
-    - Add tests for Django 1.11 (PR `#5`_)
-    - Allow for integration with UserAttributeSimilarityValidator
-      (see https://code.djangoproject.com/ticket/28127,
-      https://github.com/django/django/pull/8408, and PR `#5`_)
-    - Rename project django-improved-user (from django-simple-user)
-    - Make development default branch (PR `#6`_)
-    - Initial public release (PR `#7`_)
-    - Use Simplified BSD License instead of Revised BSD License (`#7`_)
+- Add tests for Django 1.11 (PR `#5`_)
+- Allow for integration with UserAttributeSimilarityValidator
+  (see https://code.djangoproject.com/ticket/28127,
+  https://github.com/django/django/pull/8408, and PR `#5`_)
+- Rename project django-improved-user (from django-simple-user)
+- Make development default branch (PR `#6`_)
+- Initial public release (PR `#7`_)
+- Use Simplified BSD License instead of Revised BSD License (`#7`_)
 
 .. _#5: https://github.com/jambonsw/django-improved-user/pull/5
 .. _#6: https://github.com/jambonsw/django-improved-user/pull/6
@@ -80,12 +79,12 @@ Next Release
 0.0.1 (2016-10-26)
 ------------------
 
-    - Simplified User model for better international handling.
-      Includes forms and admin configuration (PR `#1`_)
-    - All tests run on TravisCI (PR `#3`_)
-    - Compatible with:
-        - Python 3.4, 3.5, 3.6
-        - Django 1.8 through 1.10 (PR `#3`_ and `#4`_)
+- Simplified User model for better international handling.
+  Includes forms and admin configuration (PR `#1`_)
+- All tests run on TravisCI (PR `#3`_)
+- Compatible with:
+    - Python 3.4, 3.5, 3.6
+    - Django 1.8 through 1.10 (PR `#3`_ and `#4`_)
 
 .. _#1: https://github.com/jambonsw/django-improved-user/pull/1
 .. _#3: https://github.com/jambonsw/django-improved-user/pull/3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,19 +16,19 @@ Next Release
   at time of writing). This increases test coverage across the board and
   updates the test suite to check for parity between Django's User API
   and Improved User's API as well as check for the same security issues.
-  (PR `#18_`)
+  (PR `#18`)
 - UserManager raises a friendly error if the developer tries to pass a
-  username argument (PR `#18_`)
+  username argument (PR `#18`_)
 - Password errors are shown above both password fields
-  (PR `#18_`)
+  (PR `#18`_)
 - Bugfix: UserManager handles is_staff, is_active, and is_superuser
-  correctly (PR `#18_`)
-- Bugfix: User has email normalized during Model.clean phase (PR `#18_`)
+  correctly (PR `#18`_)
+- Bugfix: User has email normalized during Model.clean phase (PR `#18`_)
 - Bugfix: UserAdmin requires short_name in both add and change
-  (previously only in change; PR `#18_`)
+  (previously only in change; PR `#18`_)
 - Bugfix: UserAdmin uses correct relative path URL for password change
-  in all versions of Django (was not working in Django 1.9+) (PR `#18_`)
-- Bugfix: Runtests correctly handles test specification (PR `#18_`)
+  in all versions of Django (was not working in Django 1.9+) (PR `#18`_)
+- Bugfix: Runtests correctly handles test specification (PR `#18`_)
 
 .. _#16: https://github.com/jambonsw/django-improved-user/pull/16
 .. _#18: https://github.com/jambonsw/django-improved-user/pull/18

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,8 +7,27 @@ Next Release
 
 - Integrate coverage and codecov service (PR `#16`_)
 - Make TravisCI test builds public (first seen in PR `#16`_)
+- Merge appropriate tests from Django master (1.11.3 is current release
+  at time of writing). This increases test coverage across the board and
+  updates the test suite to check for parity between Django's User API
+  and Improved User's API as well as check for the same security issues.
+  (PR `18_`)
+- UserManager raises a friendly error if the developer tries to pass a
+  username argument (PR `18_`)
+- Password errors are shown above both password fields
+  (PR `18_`)
+- Bugfix: UserManager handles is_staff, is_active, and is_superuser
+  correctly (PR `18_`)
+- Bugfix: User has email normalized during Model.clean phase (PR `18_`)
+- Bugfix: UserAdmin requires short_name in both add and change
+  (previously only in change; PR `18_`)
+- Bugfix: UserAdmin uses correct relative path URL for password change
+  in all versions of Django (was not working in Django 1.9+) (PR `18_`)
+- Bugfix: Runtests correctly handles test specification, e.g.:
+  ``$ ./runtests tests.test_basic`` (PR `18_`)
 
 .. _#16: https://github.com/jambonsw/django-improved-user/pull/16
+.. _#18: https://github.com/jambonsw/django-improved-user/pull/18
 
 0.2.0 (2017-07-30)
 ------------------

--- a/runtests.py
+++ b/runtests.py
@@ -20,7 +20,7 @@ except ImportError:
 
 def run_test_suite(*args):
     """Heart of script: setup Django, run tests based on args"""
-    test_args = args or []
+    test_args = list(args) or []
 
     settings.configure(
         DATABASES={

--- a/runtests.py
+++ b/runtests.py
@@ -30,14 +30,33 @@ def run_test_suite(*args):
             },
         },
         INSTALLED_APPS=[
+            'django.contrib.admin',
             'django.contrib.auth',
             'django.contrib.contenttypes',
             'django.contrib.sessions',
             'django.contrib.sites',
             'improved_user.apps.ImprovedUserConfig',
         ],
+        MIDDLEWARE=[
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+        ],
+        SITE_ID=1,
         AUTH_USER_MODEL='improved_user.User',
         FIXTURE_DIRS=(join(dirname(__file__), 'tests', 'fixtures'),),
+        TEMPLATES=[{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        }],
+
     )
     setup()
     execute_from_command_line(['manage.py', 'test'] + test_args)

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,7 @@ class CustomCheckCommand(CheckCommand):
     def initialize_options(self):
         """Setup superclass and new options"""
         super().initialize_options()
-        # pylint: disable=attribute-defined-outside-init
-        self.enforce_email = 0
+        self.enforce_email = 0  # pylint:disable=attribute-defined-outside-init
 
     def check_metadata(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ class CustomTestCommand(TestCommand):
 
 setup(
     name='django-improved-user',
-    version='0.2.0',
+    version='0.3.0',
     description=(
         'A custom Django user model for best practices email-based login.'
     ),

--- a/src/improved_user/__init__.py
+++ b/src/improved_user/__init__.py
@@ -9,3 +9,4 @@ https://docs.djangoproject.com/en/stable/ref/applications/#configuring-applicati
 """
 # pylint: disable=invalid-name
 default_app_config = 'improved_user.apps.ImprovedUserConfig'
+# pylint: enable=invalid-name

--- a/src/improved_user/admin.py
+++ b/src/improved_user/admin.py
@@ -19,7 +19,7 @@ class UserAdmin(BaseUserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('email', 'password1', 'password2'),
+            'fields': ('email', 'short_name', 'password1', 'password2'),
         }),
     )
     form = UserChangeForm

--- a/src/improved_user/forms.py
+++ b/src/improved_user/forms.py
@@ -43,24 +43,27 @@ class AbstractUserCreationForm(forms.ModelForm):
         'password_mismatch': _("The two password fields didn't match."),
     }
 
+    # TODO: move this to field when Django 1.8 support dropped
+    password_kwargs = {'strip': False} if DjangoVersion >= (1, 9) else {}
+
     password1 = forms.CharField(
         label=_('Password'),
-        # TODO: Uncomment below when Dj1.8 dropped
-        # strip=False,
         widget=forms.PasswordInput,
-        help_text=password_validation.password_validators_help_text_html())
+        help_text=password_validation.password_validators_help_text_html(),
+        **password_kwargs  # noqa: C815
+    )
     password2 = forms.CharField(
         label=_('Password confirmation'),
-        # TODO: Uncomment below when Dj1.8 dropped
-        # strip=False,
         widget=forms.PasswordInput,
-        help_text=_('Enter the same password as above, for verification.'))
+        help_text=_('Enter the same password as above, for verification.'),
+        **password_kwargs  # noqa: C815
+    )
 
     def clean_password2(self):
         """
         Check wether password 1 and password 2 are equivalent
 
-        While ideally this would be done in clean, there is a chance the
+        While ideally this would be done in clean, there is a chance a
         superclass could declare clean and forget to call super. We
         therefore opt to run this password mismatch check in password2
         clean, but to show the error above password1 (as we are unsure

--- a/src/improved_user/forms.py
+++ b/src/improved_user/forms.py
@@ -1,5 +1,5 @@
 """Forms for Creating and Updating Improved Users"""
-from django import forms
+from django import VERSION as DjangoVersion, forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
@@ -45,12 +45,14 @@ class AbstractUserCreationForm(forms.ModelForm):
 
     password1 = forms.CharField(
         label=_('Password'),
-        strip=False,
+        # TODO: Uncomment below when Dj1.8 dropped
+        # strip=False,
         widget=forms.PasswordInput,
         help_text=password_validation.password_validators_help_text_html())
     password2 = forms.CharField(
         label=_('Password confirmation'),
-        strip=False,
+        # TODO: Uncomment below when Dj1.8 dropped
+        # strip=False,
         widget=forms.PasswordInput,
         help_text=_('Enter the same password as above, for verification.'))
 
@@ -192,6 +194,8 @@ class AbstractUserChangeForm(forms.ModelForm):
         if (hasattr(self, 'rel_password_url')
                 and self.rel_password_url is not None):
             return self.rel_password_url
+        if DjangoVersion < (1, 9):
+            return './password/'
         return '../password/'
 
     def clean_password(self):

--- a/src/improved_user/models.py
+++ b/src/improved_user/models.py
@@ -16,10 +16,14 @@ class UserManager(BaseUserManager):
         """Helper method to save a User with improved user fields"""
         if not email:
             raise ValueError('An email address must be provided.')
+        if 'username' in extra_fields:
+            raise ValueError(
+                'The Improved User model does not have a username; '
+                'it uses only email')
         now = timezone.now()
         user = self.model(
             email=self.normalize_email(email),
-            is_active=True, is_staff=is_staff, is_superuser=is_superuser,
+            is_staff=is_staff, is_superuser=is_superuser,
             last_login=now, date_joined=now, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
@@ -27,11 +31,19 @@ class UserManager(BaseUserManager):
 
     def create_user(self, email=None, password=None, **extra_fields):
         """Save new User with email and password"""
-        return self._create_user(email, password, False, False, **extra_fields)
+        extra_fields.setdefault('is_staff', False)
+        extra_fields.setdefault('is_superuser', False)
+        return self._create_user(email, password, **extra_fields)
 
     def create_superuser(self, email, password, **extra_fields):
         """Save new User with is_staff and is_superuser set to True"""
-        return self._create_user(email, password, True, True, **extra_fields)
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+        return self._create_user(email, password, **extra_fields)
 
 
 class ImprovedIdentityMixin(models.Model):
@@ -76,6 +88,7 @@ class AbstractUser(ImprovedIdentityMixin, PermissionsMixin, AbstractBaseUser):
 
     objects = UserManager()
 
+    EMAIL_FIELD = 'email'
     USERNAME_FIELD = 'email'
     # misnomer; fields Dj prompts for when user calls createsuperuser
     # https://docs.djangoproject.com/en/stable/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS
@@ -85,6 +98,10 @@ class AbstractUser(ImprovedIdentityMixin, PermissionsMixin, AbstractBaseUser):
         verbose_name = _('user')
         verbose_name_plural = _('users')
         abstract = True
+
+    def clean(self):
+        super().clean()
+        self.email = self.__class__.objects.normalize_email(self.email)
 
     def email_user(self, subject, message, from_email=None, **kwargs):
         """Sends an email to this User."""

--- a/src/improved_user/models.py
+++ b/src/improved_user/models.py
@@ -77,6 +77,8 @@ class AbstractUser(ImprovedIdentityMixin, PermissionsMixin, AbstractBaseUser):
     objects = UserManager()
 
     USERNAME_FIELD = 'email'
+    # misnomer; fields Dj prompts for when user calls createsuperuser
+    # https://docs.djangoproject.com/en/stable/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS
     REQUIRED_FIELDS = ['full_name', 'short_name']
 
     class Meta:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,248 @@
+"""Test Admin interface provided by Improved User"""
+import os
+import re
+
+from django.contrib.admin.models import LogEntry
+from django.contrib.auth import SESSION_KEY
+from django.test import TestCase, override_settings
+from django.test.utils import patch_logger
+from django.urls import reverse
+from django.utils.encoding import force_text
+
+from improved_user.admin import UserAdmin
+from improved_user.forms import UserChangeForm, UserCreationForm
+from improved_user.models import User
+
+
+# Redirect in test_user_change_password will fail if session auth hash
+# isn't updated after password change (#21649)
+@override_settings(ROOT_URLCONF='tests.urls')
+class UserAdminTests(TestCase):
+    """Based off django.tests.auth_tests.test_views.ChangelistTests"""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Called by TestCase during initialization; creates users"""
+        cls.user1 = User.objects.create_user(
+            email='testclient@example.com',
+            password='password',
+            short_name='client',
+        )
+        cls.user2 = User.objects.create_user(
+            email='staffmember@example.com',
+            password='password',
+            short_name='staff',
+        )
+
+    def setUp(self):
+        """Make user1 a superuser before logging in."""
+        User.objects\
+            .filter(email='testclient@example.com')\
+            .update(is_staff=True, is_superuser=True)
+        self.login()
+        self.admin = User.objects.get(pk=self.user1.pk)
+
+    def login(self, username='testclient@example.com', password='password'):
+        """Helper function to login the user (specified or default)"""
+        response = self.client.post('/login/', {
+            'username': username,
+            'password': password,
+        })
+        self.assertIn(SESSION_KEY, self.client.session)
+        return response
+
+    def logout(self):
+        """Helper function to logout the user"""
+        response = self.client.get('/admin/logout/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(SESSION_KEY, self.client.session)
+
+    def get_user_data(self, user):  # pylint: disable=no-self-use
+        """Generate dictionary of values to compare against"""
+        return {
+            'email': user.email,
+            'password': user.password,
+            'is_active': user.is_active,
+            'is_staff': user.is_staff,
+            'is_superuser': user.is_superuser,
+            'last_login_0': user.last_login.strftime('%Y-%m-%d'),
+            'last_login_1': user.last_login.strftime('%H:%M:%S'),
+            'initial-last_login_0': user.last_login.strftime('%Y-%m-%d'),
+            'initial-last_login_1': user.last_login.strftime('%H:%M:%S'),
+            'date_joined_0': user.date_joined.strftime('%Y-%m-%d'),
+            'date_joined_1': user.date_joined.strftime('%H:%M:%S'),
+            'initial-date_joined_0': user.date_joined.strftime('%Y-%m-%d'),
+            'initial-date_joined_1': user.date_joined.strftime('%H:%M:%S'),
+            'full_name': user.full_name,
+            'short_name': user.short_name,
+        }
+
+    def test_display_fields(self):
+        """Test that admin shows all user fields"""
+        excluded_model_fields = ['id', 'logentry']
+        model_fields = set(
+            field.name for field in User._meta.get_fields()
+            if field.name not in excluded_model_fields
+        )
+        admin_fieldset_fields = set(
+            fieldname
+            for name, fieldset in UserAdmin.fieldsets
+            for fieldname in fieldset['fields']
+        )
+        self.assertEqual(model_fields, admin_fieldset_fields)
+
+    def test_add_has_required_fields(self):
+        """Test all required fields in Admin Add view"""
+        excluded_model_fields = ['date_joined', 'password']
+        required_model_fields = [
+            field.name
+            for field in User._meta.get_fields()
+            if (field.name not in excluded_model_fields
+                and hasattr(field, 'null') and field.null is False
+                and hasattr(field, 'blank') and field.blank is False)
+        ]
+        extra_form_fields = [
+            field_name for field_name in list(UserCreationForm.declared_fields)
+        ]
+        admin_add_fields = [
+            fieldname
+            for name, fieldset in UserAdmin.add_fieldsets
+            for fieldname in fieldset['fields']
+        ]
+        for field in required_model_fields+extra_form_fields:
+            with self.subTest(field=field):
+                self.assertIn(field, admin_add_fields)
+
+    def test_correct_forms_used(self):
+        """Test that UserAdmin uses the right forms"""
+        self.assertIs(UserAdmin.add_form, UserCreationForm)
+        self.assertIs(UserAdmin.form, UserChangeForm)
+
+    def test_user_add(self):
+        """Ensure the admin add view works correctly"""
+        # we can get the form view
+        get_response = self.client.get(
+            reverse('auth_test_admin:improved_user_user_add'))
+        self.assertEqual(get_response.status_code, 200)
+        # we can create new users in the form view
+        post_response = self.client.post(
+            reverse('auth_test_admin:improved_user_user_add'),
+            {
+                'email': 'newuser@example.com',
+                'short_name': 'New User',
+                'password1': 'passw0rd1!',
+                'password2': 'passw0rd1!',
+            },
+            follow=True,
+        )
+        self.assertEqual(post_response.status_code, 200)
+        self.assertTrue(
+            User.objects.filter(email='newuser@example.com').exists())
+        new_user = User.objects.get(email='newuser@example.com')
+        self.assertTrue(new_user.check_password('passw0rd1!'))
+        self.assertEqual(new_user.short_name, 'New User')
+
+    def test_user_change_email(self):
+        """Test that user can change email in Admin"""
+        data = self.get_user_data(self.admin)
+        data['email'] = 'new_' + data['email']
+        response = self.client.post(
+            reverse(
+                'auth_test_admin:improved_user_user_change',
+                args=(self.admin.pk,),
+            ),
+            data,
+        )
+        self.assertRedirects(
+            response,
+            reverse('auth_test_admin:improved_user_user_changelist'))
+        row = LogEntry.objects.latest('id')
+        self.assertEqual(row.get_change_message(), 'Changed email.')
+
+    def test_user_not_change(self):
+        """Test that message is raised when form submitted unchanged"""
+        response = self.client.post(
+            reverse(
+                'auth_test_admin:improved_user_user_change',
+                args=(self.admin.pk,),
+            ),
+            self.get_user_data(self.admin),
+        )
+        self.assertRedirects(
+            response,
+            reverse('auth_test_admin:improved_user_user_changelist'))
+        row = LogEntry.objects.latest('id')
+        self.assertEqual(row.get_change_message(), 'No fields changed.')
+
+    def test_user_change_password(self):
+        """Test that URL to change password form is correct"""
+        user_change_url = reverse(
+            'auth_test_admin:improved_user_user_change', args=(self.admin.pk,))
+        password_change_url = reverse(
+            'auth_test_admin:auth_user_password_change',
+            args=(self.admin.pk,))
+
+        response = self.client.get(user_change_url)
+        # Test the link inside password field help_text.
+        rel_link = re.search(
+            r'you can change the password using '
+            r'<a href="([^"]*)">this form</a>',
+            force_text(response.content),
+        ).groups()[0]
+        self.assertEqual(
+            os.path.normpath(user_change_url + rel_link),
+            os.path.normpath(password_change_url),
+        )
+
+        response = self.client.post(
+            password_change_url,
+            {
+                'password1': 'password1',
+                'password2': 'password1',
+            },
+        )
+        self.assertRedirects(response, user_change_url)
+        row = LogEntry.objects.latest('id')
+        self.assertEqual(row.get_change_message(), 'Changed password.')
+        self.logout()
+        self.login(password='password1')
+
+    def test_user_change_different_user_password(self):
+        """Test that administrator can update other Users' passwords"""
+        user = User.objects.get(email='staffmember@example.com')
+        response = self.client.post(
+            reverse(
+                'auth_test_admin:auth_user_password_change',
+                args=(user.pk,),
+            ),
+            {
+                'password1': 'password1',
+                'password2': 'password1',
+            },
+        )
+        self.assertRedirects(
+            response,
+            reverse(
+                'auth_test_admin:improved_user_user_change',
+                args=(user.pk,)))
+        row = LogEntry.objects.latest('id')
+        self.assertEqual(row.user_id, self.admin.pk)
+        self.assertEqual(row.object_id, str(user.pk))
+        self.assertEqual(row.get_change_message(), 'Changed password.')
+
+    def test_changelist_disallows_password_lookups(self):
+        """Users shouldn't be allowed to guess password
+
+        Checks against repeated password__startswith queries
+        https://code.djangoproject.com/ticket/20078
+
+        """
+        # A lookup that tries to filter on password isn't OK
+        with patch_logger(
+            'django.security.DisallowedModelAdminLookup', 'error',
+        ) as logger_calls:
+            response = self.client.get(
+                reverse('auth_test_admin:improved_user_user_changelist')
+                + '?password__startswith=sha1$')
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(len(logger_calls), 1)

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 from unittest.mock import patch
 
-import django
+from django import VERSION as DjangoVersion
 from django.contrib.auth import authenticate
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.hashers import MD5PasswordHasher
@@ -194,10 +194,10 @@ class ImprovedUserModelBackendTest(TestCase):
             {'auth.test_group'})
 
         # In Django 1.10, is_anonymous became a property.
-        if django.VERSION >= (1, 10):
+        if DjangoVersion >= (1, 10):
             is_anon_mock = True
         else:
-            is_anon_mock = lambda: True  # noqa: E731
+            is_anon_mock = lambda s: True  # noqa: E731
         with patch.object(self.UserModel, 'is_anonymous', is_anon_mock):
             self.assertEqual(backend.get_all_permissions(user), set())
             self.assertEqual(backend.get_user_permissions(user), set())

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -1,3 +1,7 @@
+"""Test Improved User against Django's default backend"""
+# pylint: disable=protected-access
+from unittest.mock import patch
+
 import django
 from django.contrib.auth import authenticate
 from django.contrib.auth.backends import ModelBackend
@@ -14,21 +18,52 @@ class CountingMD5PasswordHasher(MD5PasswordHasher):
 
     calls = 0
 
-    def encode(self, *args, **kwargs):
+    def encode(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """Add counter and call superclass to actually hash"""
         type(self).calls += 1
-        return super(CountingMD5PasswordHasher, self).encode(*args, **kwargs)
+        return super().encode(*args, **kwargs)
 
 
-class BaseModelBackendTest(object):
+class ImprovedUserModelBackendTest(TestCase):
     """
-    A base class for tests that need to validate the ModelBackend
-    with different User models. Subclasses should define a class
-    level UserModel attribute, and a create_users() method to
-    construct two users for test purposes.
+    Tests for the ModelBackend using the Improved User model.
+
+    Looks for problems that may arise because auth.User
+    is missing from db.
+
+    The specific problem is queries on .filter(groups__user) et al,
+    which makes an implicit assumption that the user model is called
+    'User'. In production, the auth.User table won't exist, so the
+    requested join won't exist either; in testing, the auth.User *does*
+    exist, and so does the join. However, the join table won't contain
+    any useful data; for testing, we check that the data we expect
+    actually does exist.
     """
+
+    UserModel = User
     backend = 'django.contrib.auth.backends.ModelBackend'
 
+    def create_users(self):
+        """Test utility to create users"""
+        self.user = User._default_manager.create_user(
+            email='test@example.com',
+            password='test',
+        )
+        self.superuser = User._default_manager.create_superuser(
+            email='test2@example.com',
+            password='test',
+        )
+
+    def test_authenticate(self):
+        """Additional test to ensure authentication"""
+        authenticated_user = authenticate(
+            email='test@example.com', password='test')
+        self.assertEqual(self.user, authenticated_user)
+
+    # Code below this point is from Django's BaseModelBackend superclass
+
     def setUp(self):
+        """Add the backend to current settings"""
         self.patched_settings = modify_settings(
             AUTHENTICATION_BACKENDS={'append': self.backend},
         )
@@ -36,6 +71,7 @@ class BaseModelBackendTest(object):
         self.create_users()
 
     def tearDown(self):
+        """Remove patched settings and flush cache"""
         self.patched_settings.disable()
         # The custom_perms test messes with ContentTypes, which will
         # be cached; flush the cache to ensure there are no side effects
@@ -43,24 +79,26 @@ class BaseModelBackendTest(object):
         ContentType.objects.clear_cache()
 
     def test_has_perm(self):
+        """Refresh the user model to test permissions"""
         user = self.UserModel._default_manager.get(pk=self.user.pk)
-        self.assertEqual(user.has_perm('auth.test'), False)
+        self.assertIs(user.has_perm('auth.test'), False)
 
         user.is_staff = True
         user.save()
-        self.assertEqual(user.has_perm('auth.test'), False)
+        self.assertIs(user.has_perm('auth.test'), False)
 
         user.is_superuser = True
         user.save()
-        self.assertEqual(user.has_perm('auth.test'), True)
+        self.assertIs(user.has_perm('auth.test'), True)
 
         user.is_staff = True
         user.is_superuser = True
         user.is_active = False
         user.save()
-        self.assertEqual(user.has_perm('auth.test'), False)
+        self.assertIs(user.has_perm('auth.test'), False)
 
     def test_custom_perms(self):
+        """Check interactions with custom permissions and groups"""
         user = self.UserModel._default_manager.get(pk=self.user.pk)
         content_type = ContentType.objects.get_for_model(Group)
         perm = Permission.objects.create(
@@ -69,10 +107,10 @@ class BaseModelBackendTest(object):
 
         # reloading user to purge the _perm_cache
         user = self.UserModel._default_manager.get(pk=self.user.pk)
-        self.assertEqual(user.get_all_permissions() == {'auth.test'}, True)
+        self.assertEqual(user.get_all_permissions(), {'auth.test'})
         self.assertEqual(user.get_group_permissions(), set())
-        self.assertEqual(user.has_module_perms('Group'), False)
-        self.assertEqual(user.has_module_perms('auth'), True)
+        self.assertIs(user.has_module_perms('Group'), False)
+        self.assertIs(user.has_module_perms('auth'), True)
 
         perm = Permission.objects.create(
             name='test2', content_type=content_type, codename='test2')
@@ -84,9 +122,9 @@ class BaseModelBackendTest(object):
         self.assertEqual(
             user.get_all_permissions(),
             {'auth.test2', 'auth.test', 'auth.test3'})
-        self.assertEqual(user.has_perm('test'), False)
-        self.assertEqual(user.has_perm('auth.test'), True)
-        self.assertEqual(user.has_perms(['auth.test2', 'auth.test3']), True)
+        self.assertIs(user.has_perm('test'), False)
+        self.assertIs(user.has_perm('auth.test'), True)
+        self.assertIs(user.has_perms(['auth.test2', 'auth.test3']), True)
 
         perm = Permission.objects.create(
             name='test_group',
@@ -99,30 +137,37 @@ class BaseModelBackendTest(object):
         exp = {'auth.test2', 'auth.test', 'auth.test3', 'auth.test_group'}
         self.assertEqual(user.get_all_permissions(), exp)
         self.assertEqual(user.get_group_permissions(), {'auth.test_group'})
-        self.assertEqual(
-            user.has_perms(['auth.test3', 'auth.test_group']), True)
+        self.assertIs(user.has_perms(['auth.test3', 'auth.test_group']), True)
 
         user = AnonymousUser()
-        self.assertEqual(user.has_perm('test'), False)
-        self.assertEqual(user.has_perms(['auth.test2', 'auth.test3']), False)
+        self.assertIs(user.has_perm('test'), False)
+        self.assertIs(user.has_perms(['auth.test2', 'auth.test3']), False)
 
     def test_has_no_object_perm(self):
-        """Regressiontest for #12462"""
+        """Verify proper return of perm object check
+
+        Regression test for #12462
+        https://code.djangoproject.com/ticket/12462
+
+        """
         user = self.UserModel._default_manager.get(pk=self.user.pk)
         content_type = ContentType.objects.get_for_model(Group)
         perm = Permission.objects.create(
             name='test', content_type=content_type, codename='test')
         user.user_permissions.add(perm)
 
-        self.assertEqual(user.has_perm('auth.test', 'object'), False)
+        self.assertIs(user.has_perm('auth.test', 'object'), False)
         self.assertEqual(user.get_all_permissions('object'), set())
-        self.assertEqual(user.has_perm('auth.test'), True)
+        self.assertIs(user.has_perm('auth.test'), True)
         self.assertEqual(user.get_all_permissions(), {'auth.test'})
 
     def test_anonymous_has_no_permissions(self):
-        """
+        """Anonymous users shouldn't have permissions in ModelBackend
+
         #17903 -- Anonymous users shouldn't have permissions in
         ModelBackend.get_(all|user|group)_permissions().
+
+        https://code.djangoproject.com/ticket/17903
         """
         backend = ModelBackend()
 
@@ -149,22 +194,22 @@ class BaseModelBackendTest(object):
             {'auth.test_group'})
 
         # In Django 1.10, is_anonymous became a property.
-        is_anon = self.UserModel.is_anonymous
         if django.VERSION >= (1, 10):
-            self.UserModel.is_anonymous = True
+            is_anon_mock = True
         else:
-            user.is_anonymous = lambda: True
-
-        self.assertEqual(backend.get_all_permissions(user), set())
-        self.assertEqual(backend.get_user_permissions(user), set())
-        self.assertEqual(backend.get_group_permissions(user), set())
-
-        self.UserModel.is_anonymous = is_anon
+            is_anon_mock = lambda: True  # noqa: E731
+        with patch.object(self.UserModel, 'is_anonymous', is_anon_mock):
+            self.assertEqual(backend.get_all_permissions(user), set())
+            self.assertEqual(backend.get_user_permissions(user), set())
+            self.assertEqual(backend.get_group_permissions(user), set())
 
     def test_inactive_has_no_permissions(self):
-        """
+        """Inactive users shouldn't have permissions in ModelBackend
+
         #17903 -- Inactive users shouldn't have permissions in
         ModelBackend.get_(all|user|group)_permissions().
+
+        https://code.djangoproject.com/ticket/17903
         """
         backend = ModelBackend()
 
@@ -198,7 +243,12 @@ class BaseModelBackendTest(object):
         self.assertEqual(backend.get_group_permissions(user), set())
 
     def test_get_all_superuser_permissions(self):
-        """A superuser has all permissions. Refs #14795."""
+        """A superuser has all permissions.
+
+        Refs #14795.
+        https://code.djangoproject.com/ticket/14795
+
+        """
         user = self.UserModel._default_manager.get(pk=self.superuser.pk)
         self.assertEqual(
             len(user.get_all_permissions()),
@@ -208,9 +258,10 @@ class BaseModelBackendTest(object):
         PASSWORD_HASHERS=[
             'tests.test_auth_backends.CountingMD5PasswordHasher'])
     def test_authentication_timing(self):
-        """
-        Hasher is run once regardless of whether the user exists.
+        """Hasher is run once regardless of whether the user exists.
+
         Refs #20760.
+        https://code.djangoproject.com/ticket/20760
 
         """
         # Re-set the password, because this tests overrides PASSWORD_HASHERS
@@ -225,34 +276,3 @@ class BaseModelBackendTest(object):
         CountingMD5PasswordHasher.calls = 0
         authenticate(username='no_such_user', password='test')
         self.assertEqual(CountingMD5PasswordHasher.calls, 1)
-
-
-class ModelBackendTest(BaseModelBackendTest, TestCase):
-    """
-    Tests for the ModelBackend using the Improved User model.
-
-    This isn't a perfect test, because both auth.User and
-    improved_user.User are synchronized to the database, which wouldn't
-    ordinarily happen in production. As a result, it doesn't catch
-    errors caused by the non- existence of the User table.
-
-    The specific problem is queries on .filter(groups__user) et al,
-    which makes an implicit assumption that the user model is called
-    'User'. In production, the auth.User table won't exist, so the
-    requested join won't exist either; in testing, the auth.User *does*
-    exist, and so does the join. However, the join table won't contain
-    any useful data; for testing, we check that the data we expect
-    actually does exist.
-    """
-
-    UserModel = User
-
-    def create_users(self):
-        self.user = User._default_manager.create_user(
-            email='test@example.com',
-            password='test',
-        )
-        self.superuser = User._default_manager.create_superuser(
-            email='test2@example.com',
-            password='test',
-        )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,158 @@
+"""Test basic functionality; test API used by a Django project developer"""
+from django.contrib.auth import get_user, get_user_model
+from django.http import HttpRequest
+from django.test import TestCase
+from django.utils import translation
+
+from improved_user.models import User
+
+
+class BasicTestCase(TestCase):
+    """Test Improved User to mimic Django Auth User
+
+    The goal is to provide a User model that can be used as a drop-in
+    replacement for Django Auth User, all while providing mixin classes
+    to allow developers to easily extend their own class. These tests
+    focus on the first part.
+    """
+
+    def test_user_creation(self):
+        """Users can be created and can set/modify their password"""
+        email_lowercase = 'test@example.com'
+        password = 'password1!'
+        user = User.objects.create_user(email_lowercase, password)
+        self.assertEqual(user.email, email_lowercase)
+        self.assertTrue(user.has_usable_password())
+        self.assertFalse(user.check_password('wrong'))
+        self.assertTrue(user.check_password(password))
+
+        # Check we can manually set an unusable password
+        user.set_unusable_password()
+        user.save()
+        self.assertFalse(user.check_password(password))
+        self.assertFalse(user.has_usable_password())
+        user.set_password(password)
+        self.assertTrue(user.check_password(password))
+        user.set_password(None)
+        self.assertFalse(user.has_usable_password())
+
+        # can add short and full name
+        user.full_name = 'John Smith'
+        user.short_name = 'John'
+        user.save()
+        self.assertEqual(user.get_full_name(), 'John Smith')
+        self.assertEqual(user.get_short_name(), 'John')
+
+    def test_user_creation_without_password(self):
+        """Users can be created without password"""
+        user = User.objects.create_user('test@example.com')
+        self.assertFalse(user.has_usable_password())
+
+    def test_unicode_email(self):  # pylint: disable=no-self-use
+        """Unicode emails are allowed in Model
+
+        Note that Django's Email field validator will error on
+        the following, meaning that while the model accepts
+        these values, the forms will not. Some work required.
+
+        """
+        User.objects.create_user('Pelé@example.com')
+        User.objects.create_user('δοκιμή@παράδειγμα.δοκιμή')
+        User.objects.create_user('我買@屋企.香港')
+        User.objects.create_user('甲斐@黒川.日本')
+        User.objects.create_user('чебурашка@ящик-с-апельсинами.рф')
+        User.objects.create_user('संपर्क@डाटामेल.भारत')
+        # Unlike usernames, emails are not normalized,
+        # identical glyphs with different codepoints are allowed
+        omega_emails = 'iamtheΩ@email.com'  # U+03A9 GREEK CAPITAL LETTER OMEGA
+        ohm_username = 'iamtheΩ@email.com'  # U+2126 OHM SIGN
+        User.objects.create_user(omega_emails)
+        User.objects.create_user(ohm_username)
+
+    def test_user_permissions(self):
+        """Test normal user's authentication permissions"""
+        user = User.objects.create_user('test@example.com')
+        # Check authentication/permissions
+        self.assertFalse(user.is_anonymous)
+        self.assertTrue(user.is_authenticated)
+        self.assertFalse(user.is_staff)
+        self.assertTrue(user.is_active)
+        self.assertFalse(user.is_superuser)
+
+    def test_superuser_permissions(self):
+        """Test superuser's authentication permissions"""
+        user = User.objects.create_superuser('test@example.com', 'password1!')
+        self.assertFalse(user.is_anonymous)
+        self.assertTrue(user.is_authenticated)
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.is_active)
+        self.assertTrue(user.is_staff)
+
+    def test_username_getter(self):
+        """Check username getter method"""
+        user = User.objects.create_user('test@example.com')
+        self.assertEqual(user.get_username(), 'test@example.com')
+
+    def test_default_email(self):
+        """Test correct email field used"""
+        user = User()
+        self.assertEqual(user.get_email_field_name(), 'email')
+
+    def test_is_active(self):
+        """Test that is_active can be modified"""
+        user = User.objects.create(email='foo@bar.com')
+        # is_active is true by default
+        self.assertIs(user.is_active, True)
+        user.is_active = False
+        user.save()
+        user_fetched = User.objects.get(pk=user.pk)
+        # the is_active flag is saved
+        self.assertIs(user_fetched.is_active, False)
+
+    def test_is_staff(self):
+        """Test that is_staff can be modified"""
+        user = User.objects.create(email='foo@bar.com')
+        # is_active is true by default
+        self.assertIs(user.is_staff, False)
+        user.is_staff = True
+        user.save()
+        user_fetched = User.objects.get(pk=user.pk)
+        # the is_active flag is saved
+        self.assertIs(user_fetched.is_staff, True)
+
+    def test_is_superuser(self):
+        """Test that is_superuser can be modified"""
+        user = User.objects.create(email='foo@bar.com')
+        # is_active is true by default
+        self.assertIs(user.is_superuser, False)
+        user.is_superuser = True
+        user.save()
+        user_fetched = User.objects.get(pk=user.pk)
+        # the is_active flag is saved
+        self.assertIs(user_fetched.is_superuser, True)
+
+    def test_get_user_model(self):
+        """The improved user model can be retrieved"""
+        self.assertEqual(get_user_model(), User)
+        with self.assertRaises(AttributeError):
+            from django.contrib.auth.models import User as DjangoUser
+            DjangoUser.objects.all()
+
+    def test_user_verbose_names_translatable(self):
+        """User model verbose names are translatable (#19945)"""
+        with translation.override('en'):
+            self.assertEqual(User._meta.verbose_name, 'user')
+            self.assertEqual(User._meta.verbose_name_plural, 'users')
+        with translation.override('es'):
+            self.assertEqual(User._meta.verbose_name, 'usuario')
+            self.assertEqual(User._meta.verbose_name_plural, 'usuarios')
+
+    def test_get_user(self):
+        """Improved User can be extracted from request"""
+        created_user = User.objects.create_user('test@example.com', 'testpw')
+        self.client.login(username='test@example.com', password='testpw')
+        request = HttpRequest()
+        request.session = self.client.session
+        user = get_user(request)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.email, created_user.email)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,7 @@
 """Test basic functionality; test API used by a Django project developer"""
+from unittest import skipUnless
+
+from django import VERSION as DjangoVersion
 from django.contrib.auth import get_user, get_user_model
 from django.http import HttpRequest
 from django.test import TestCase
@@ -73,8 +76,12 @@ class BasicTestCase(TestCase):
         """Test normal user's authentication permissions"""
         user = User.objects.create_user('test@example.com')
         # Check authentication/permissions
-        self.assertFalse(user.is_anonymous)
-        self.assertTrue(user.is_authenticated)
+        if DjangoVersion >= (1, 10):
+            self.assertFalse(user.is_anonymous)
+            self.assertTrue(user.is_authenticated)
+        else:
+            self.assertFalse(user.is_anonymous())
+            self.assertTrue(user.is_authenticated())
         self.assertFalse(user.is_staff)
         self.assertTrue(user.is_active)
         self.assertFalse(user.is_superuser)
@@ -82,8 +89,12 @@ class BasicTestCase(TestCase):
     def test_superuser_permissions(self):
         """Test superuser's authentication permissions"""
         user = User.objects.create_superuser('test@example.com', 'password1!')
-        self.assertFalse(user.is_anonymous)
-        self.assertTrue(user.is_authenticated)
+        if DjangoVersion >= (1, 10):
+            self.assertFalse(user.is_anonymous)
+            self.assertTrue(user.is_authenticated)
+        else:
+            self.assertFalse(user.is_anonymous())
+            self.assertTrue(user.is_authenticated())
         self.assertTrue(user.is_superuser)
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_staff)
@@ -93,10 +104,17 @@ class BasicTestCase(TestCase):
         user = User.objects.create_user('test@example.com')
         self.assertEqual(user.get_username(), 'test@example.com')
 
-    def test_default_email(self):
-        """Test correct email field used"""
+    @skipUnless(
+        DjangoVersion >= (1, 11),
+        'Method not implemented until Django 1.11')
+    def test_default_email_method(self):
+        """Test correct email field used in method"""
         user = User()
         self.assertEqual(user.get_email_field_name(), 'email')
+
+    def test_default_email_field(self):
+        """Test correct email field used"""
+        self.assertEqual(User.EMAIL_FIELD, 'email')
 
     def test_is_active(self):
         """Test that is_active can be modified"""

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -228,19 +228,25 @@ class UserCreationFormTest(TestDataMixin, TestCase):
             form['password1'].errors,
             ['The password is too similar to the full name.'])
 
-    # TODO: Enable test below when Dj1.8 support dropped
-    # def test_password_whitespace_not_stripped(self):
-    #     """Ensure we aren't mangling passwords by removing whitespaces"""
-    #     data = {
-    #         'email': 'jsmith@example.com',
-    #         'password1': '   test password   ',
-    #         'password2': '   test password   ',
-    #         'short_name': 'John',
-    #     }
-    #     form = UserCreationForm(data)
-    #     self.assertTrue(form.is_valid())
-    #     self.assertEqual(form.cleaned_data['password1'], data['password1'])
-    #     self.assertEqual(form.cleaned_data['password2'], data['password2'])
+    def test_password_whitespace_not_stripped(self):
+        """Ensure we aren't mangling passwords by removing whitespaces
+
+        Starting in Django 1.9, form Charfield and subclasses allow for
+        whitestrip to be stripped automatically during the clean field
+        phase. This is a test to ensure that we are not stripping
+        whitespace from the password.
+
+        """
+        data = {
+            'email': 'jsmith@example.com',
+            'password1': '   test password   ',
+            'password2': '   test password   ',
+            'short_name': 'John',
+        }
+        form = UserCreationForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['password1'], data['password1'])
+        self.assertEqual(form.cleaned_data['password2'], data['password2'])
 
 
 class UserChangeFormTest(TestDataMixin, TestCase):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,64 +1,93 @@
+"""Test UserCreationForm and UserChangeForm"""
 from unittest import skipUnless
+from unittest.mock import patch
 
 import django
-from django.forms import Field
+from django.forms.fields import Field
 from django.test import TestCase, override_settings
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from improved_user.forms import UserChangeForm, UserCreationForm
 from improved_user.models import User
 
 
-@override_settings(
-    USE_TZ=False,
-    PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
-)
-class UserCreationFormTest(TestCase):
+class TestDataMixin:  # pylint: disable=too-few-public-methods
+    """Mixin used by both test classes below; creates users"""
 
-    fixtures = ['authtestdata.json']
+    @classmethod
+    def setUpTestData(cls):
+        """Called by TestCase during initialization; creates users"""
+        cls.u1 = User.objects.create_user(
+            email='testclient@example.com',
+            password='password',
+            short_name='tester')
+        cls.u2 = User.objects.create_user(
+            email='inactive@example.com',
+            password='password',
+            is_active=False)
+        cls.u3 = User.objects.create_user(
+            email='staff@example.com',
+            password='password')
+        cls.u4 = User.objects.create(
+            email='empty_password@example.com',
+            password='')
+        cls.u5 = User.objects.create(
+            email='unmanageable_password@example.com',
+            password='$')
+        cls.u6 = User.objects.create(
+            email='unknown_password@example.com',
+            password='foo$bar')
+
+
+class UserCreationFormTest(TestDataMixin, TestCase):
+    """Test UserCreationForm with Improved User"""
 
     def test_user_already_exists(self):
+        """Raise errors if user already exists"""
         data = {
             'email': 'testclient@example.com',
             'password1': 'test123',
             'password2': 'test123',
+            'short_name': 'John',
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
         self.assertEqual(form['email'].errors,
-                         [force_text(form.error_messages['duplicate_email'])])
+                         [str(form.error_messages['duplicate_email'])])
 
     def test_invalid_data(self):
+        """Raise errors if invalid email format"""
         data = {
-            'email': 'jsmith!',
+            'email': '%%%',
             'password1': 'test123',
             'password2': 'test123',
+            'short_name': 'John',
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form['email'].errors,
-            [_('Enter a valid email address.')])
+        validator = next(v
+                         for v in User._meta.get_field('email').validators
+                         if v.code == 'invalid')
+        self.assertEqual(form['email'].errors, [str(validator.message)])
 
     def test_password_verification(self):
-        # The verification password is incorrect.
+        """The verification password is incorrect."""
         data = {
             'email': 'jsmith@example.com',
             'password1': 'test123',
             'password2': 'test',
+            'short_name': 'John',
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form['password2'].errors,
-            [force_text(form.error_messages['password_mismatch'])])
+        self.assertEqual(form['password1'].errors,
+                         [str(form.error_messages['password_mismatch'])])
 
     def test_both_passwords(self):
-        # One (or both) passwords weren't given
+        """One (or both) passwords weren't given"""
         data = {'email': 'jsmith@example.com'}
         form = UserCreationForm(data)
-        required_error = [force_text(Field.default_error_messages['required'])]
+        required_error = [str(Field.default_error_messages['required'])]
         self.assertFalse(form.is_valid())
         self.assertEqual(form['password1'].errors, required_error)
         self.assertEqual(form['password2'].errors, required_error)
@@ -69,19 +98,23 @@ class UserCreationFormTest(TestCase):
         self.assertEqual(form['password1'].errors, required_error)
         self.assertEqual(form['password2'].errors, [])
 
-    def test_success(self):
-        # The success case.
+    @patch('django.contrib.auth.password_validation.password_changed')
+    def test_success(self, password_changed):
+        """Successful submission of form data"""
         data = {
             'email': 'jsmith@example.com',
-            'full_name': 'John Smith',
+            'full_name': 'John Smith',  # optional field
             'short_name': 'John',
             'password1': 'test123',
             'password2': 'test123',
         }
         form = UserCreationForm(data)
         self.assertTrue(form.is_valid())
-        u = form.save()
-        self.assertEqual(repr(u), '<User: jsmith@example.com>')
+        form.save(commit=False)
+        self.assertEqual(password_changed.call_count, 0)
+        user = form.save()
+        self.assertEqual(password_changed.call_count, 1)
+        self.assertEqual(repr(user), '<User: jsmith@example.com>')
 
     @skipUnless(
         django.VERSION >= (1, 9),
@@ -90,19 +123,48 @@ class UserCreationFormTest(TestCase):
         AUTH_PASSWORD_VALIDATORS=[
             {'NAME': 'django.contrib.auth.password_validation.'
                      'CommonPasswordValidator'},
-        ],
-    )
+            {'NAME': 'django.contrib.auth.password_validation.'
+                     'MinimumLengthValidator',
+             'OPTIONS': {'min_length': 12}}])
     def test_common_password(self):
+        """Ensure form works with Password Validation"""
         data = {
             'email': 'jsmith@example.com',
             'password1': 'password',
             'password2': 'password',
+            'short_name': 'John',
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form['password1'].errors,
-            ['This password is too common.'])
+        self.assertEqual(len(form['password1'].errors), 2)
+        self.assertIn(
+            'This password is too common.',
+            form['password1'].errors)
+        self.assertIn(
+            'This password is too short. '
+            'It must contain at least 12 characters.',
+            form['password1'].errors)
+
+    @skipUnless(
+        django.VERSION >= (1, 9),
+        'Password strength checks not available on Django 1.8')
+    @override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {'NAME': 'django.contrib.auth.password_validation.'
+                     'UserAttributeSimilarityValidator'}])
+    def test_validates_password_similarity_length(self):
+        """Test misconfigured-similarity validator catches email"""
+        data = {
+            'email': 'jsmith@example.com',
+            'password1': 'jsmith',
+            'password2': 'jsmith',
+            'short_name': 'John',
+        }
+        form = UserCreationForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            'The password is too similar to the email address.',
+            form['password1'].errors)
 
     @skipUnless(
         django.VERSION >= (1, 9),
@@ -112,10 +174,9 @@ class UserCreationFormTest(TestCase):
             'NAME': 'django.contrib.auth.password_validation.'
                     'UserAttributeSimilarityValidator',
             'OPTIONS': {
-                'user_attributes': ('email', 'full_name', 'short_name')},
-        }],
-    )
+                'user_attributes': ('email', 'full_name', 'short_name')}}])
     def test_password_help_text(self):
+        """Ensure UserAttributeSimilarityValidator help text is shown"""
         form = UserCreationForm()
         self.assertEqual(
             form.fields['password1'].help_text,
@@ -130,16 +191,15 @@ class UserCreationFormTest(TestCase):
             'NAME': 'django.contrib.auth.password_validation.'
                     'UserAttributeSimilarityValidator',
             'OPTIONS': {
-                'user_attributes': ('email', 'full_name', 'short_name')},
-        }],
-    )
-    def test_similar_attribute(self):
+                'user_attributes': ('email', 'full_name', 'short_name')}}])
+    def test_validates_password_with_all_data(self):
+        """Test correctly configured similarity validatior catches name"""
         data = {
             'email': 'jsmith@example.com',
             'password1': 'johndoesmith',
             'password2': 'johndoesmith',
-            'full_name': 'John Doe Smith',
             'short_name': 'John',
+            'full_name': 'John Smith',
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
@@ -147,29 +207,42 @@ class UserCreationFormTest(TestCase):
             form['password1'].errors,
             ['The password is too similar to the full name.'])
 
+    def test_password_whitespace_not_stripped(self):
+        """Ensure we aren't mangling passwords by removing whitespaces"""
+        data = {
+            'email': 'jsmith@example.com',
+            'password1': '   test password   ',
+            'password2': '   test password   ',
+            'short_name': 'John',
+        }
+        form = UserCreationForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['password1'], data['password1'])
+        self.assertEqual(form.cleaned_data['password2'], data['password2'])
 
-@override_settings(
-    USE_TZ=False,
-    PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
-)
-class UserChangeFormTest(TestCase):
 
-    fixtures = ['authtestdata.json']
+class UserChangeFormTest(TestDataMixin, TestCase):
+    """Tests for UserChangeForm"""
 
     def test_email_validity(self):
+        """Ensure Email Validation is used on User"""
         user = User.objects.get(email='testclient@example.com')
         data = {'email': 'not valid'}
         form = UserChangeForm(data, instance=user)
         self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form['email'].errors,
-            [_('Enter a valid email address.')])
+        validator = next(v
+                         for v in User._meta.get_field('email').validators
+                         if v.code == 'invalid')
+        self.assertEqual(form['email'].errors, [str(validator.message)])
 
     def test_bug_14242(self):
-        # A regression test, introduce by adding an optimization for the
-        # UserChangeForm.
+        """Regression test: allow UserChangeForm subclasses
 
+        https://code.djangoproject.com/ticket/14242
+
+        """
         class MyUserForm(UserChangeForm):
+            """Custom Subclass to check lack of user_permissions field"""
             def __init__(self, *args, **kwargs):
                 super(MyUserForm, self).__init__(*args, **kwargs)
                 self.fields['groups'].help_text = (
@@ -182,6 +255,7 @@ class UserChangeFormTest(TestCase):
         MyUserForm({})
 
     def test_unusable_password(self):
+        """Test that Django shows unusable password warning"""
         user = User.objects.get(email='empty_password@example.com')
         user.set_unusable_password()
         user.save()
@@ -189,11 +263,21 @@ class UserChangeFormTest(TestCase):
         self.assertIn(_('No password set.'), form.as_table())
 
     def test_bug_17944_empty_password(self):
+        """Test form can be used when password not set
+
+        https://code.djangoproject.com/ticket/17944
+
+        """
         user = User.objects.get(email='empty_password@example.com')
         form = UserChangeForm(instance=user)
         self.assertIn(_('No password set.'), form.as_table())
 
     def test_bug_17944_unmanageable_password(self):
+        """Test form can be used when password unmanageable
+
+        https://code.djangoproject.com/ticket/17944
+
+        """
         user = User.objects.get(email='unmanageable_password@example.com')
         form = UserChangeForm(instance=user)
         self.assertIn(
@@ -201,6 +285,11 @@ class UserChangeFormTest(TestCase):
             form.as_table())
 
     def test_bug_17944_unknown_password_algorithm(self):
+        """Test form can be used when hashing algorithm is unrecognized
+
+        https://code.djangoproject.com/ticket/17944
+
+        """
         user = User.objects.get(email='unknown_password@example.com')
         form = UserChangeForm(instance=user)
         self.assertIn(
@@ -208,7 +297,11 @@ class UserChangeFormTest(TestCase):
             form.as_table())
 
     def test_bug_19133(self):
-        """The change form does not return the password value"""
+        """The change form does not return the password value
+
+        https://code.djangoproject.com/ticket/19133
+
+        """
         # Use the form to construct the POST data
         user = User.objects.get(email='testclient@example.com')
         form_for_data = UserChangeForm(instance=user)
@@ -222,11 +315,15 @@ class UserChangeFormTest(TestCase):
         form = UserChangeForm(instance=user, data=post_data)
 
         self.assertTrue(form.is_valid())
-        self.assertEqual(
-            form.cleaned_data['password'],
-            'sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161')
+        self.assertTrue(user.check_password('password'))  # $ not in password
+        self.assertIn('$', form.cleaned_data['password'])  # hash contains $
 
     def test_bug_19349_bound_password_field(self):
+        """Test re-rendering of ReadOnlyPasswordHashWidget
+
+        https://code.djangoproject.com/ticket/19349
+
+        """
         user = User.objects.get(email='testclient@example.com')
         form = UserChangeForm(data={}, instance=user)
         # When rendering the bound password field,

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,0 +1,66 @@
+"""Test User model management commands"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from improved_user.models import User
+
+
+class CreatesuperuserManagementCommandTestCase(TestCase):
+    """Test createsuperuser management command"""
+
+    def test_basic_usage(self):
+        """Check the operation of the createsuperuser management command"""
+        # We can use the management command to create a superuser
+        new_io = StringIO()
+        call_command(
+            'createsuperuser',
+            interactive=False,
+            email='joe@somewhere.org',
+            short_name='Joe',
+            full_name='Joe Smith',
+            stdout=new_io,
+        )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, 'Superuser created successfully.')
+        user = User.objects.get(email='joe@somewhere.org')
+        self.assertEqual(user.short_name, 'Joe')
+
+        # created password should be unusable
+        self.assertFalse(user.has_usable_password())
+
+    def test_no_email_argument(self):
+        """Ensure that email is required"""
+        new_io = StringIO()
+        with self.assertRaisesMessage(CommandError,
+                                      'You must use --email with --noinput.'):
+            call_command(
+                'createsuperuser',
+                interactive=False,
+                short_name='Joe',
+                full_name='Joe Smith',
+                stdout=new_io)
+
+    def test_invalid_username(self):
+        """Creation fails if the username fails validation."""
+        email_field = User._meta.get_field('email')
+        new_io = StringIO()
+        invalid_username = ('x' * email_field.max_length) + 'y'
+
+        expected_error = (
+            'Enter a valid email address.; '
+            'Ensure this value has at most %d characters (it has %d).'
+            % (email_field.max_length, len(invalid_username))
+        )
+
+        with self.assertRaisesMessage(CommandError, expected_error):
+            call_command(
+                'createsuperuser',
+                interactive=False,
+                email=invalid_username,
+                short_name='Joe',
+                full_name='Joe Smith',
+                password='password1!',
+                stdout=new_io)

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,0 +1,95 @@
+"""Test User model manager"""
+from django.test import TestCase
+
+from improved_user.models import User, UserManager
+
+
+class UserManagerTestCase(TestCase):
+    """Test User model manager"""
+
+    def test_create_user_email_domain_normalize_rfc3696(self):
+        """Normalize email allows @ in email local section"""
+        # According to  http://tools.ietf.org/html/rfc3696#section-3
+        # the "@" symbol can be part of the local part of an email address
+        returned = UserManager.normalize_email(r'Abc\@DEF@EXAMPLE.com')
+        self.assertEqual(returned, r'Abc\@DEF@example.com')
+
+    def test_create_user_email_domain_normalize(self):
+        """Normalize email lowercases domain"""
+        returned = UserManager.normalize_email('normal@DOMAIN.COM')
+        self.assertEqual(returned, 'normal@domain.com')
+
+    def test_create_user_email_domain_normalize_with_whitespace(self):
+        """Normalize email allows whitespace in email local section"""
+        # pylint: disable=anomalous-backslash-in-string
+        returned = UserManager.normalize_email('email\ with_whitespace@D.COM')
+        self.assertEqual(returned, 'email\ with_whitespace@d.com')
+        # pylint: enable=anomalous-backslash-in-string
+
+    def test_empty_username(self):
+        """Manager raises error if email is missing"""
+        self.assertRaisesMessage(
+            ValueError,
+            'An email address must be provided.',
+            User.objects.create_user,
+            email='',
+        )
+
+    def test_create_user_is_staff(self):
+        """Check is_staff attribute is respected"""
+        email = 'normal@normal.com'
+        user = User.objects.create_user(email, is_staff=True)
+        self.assertEqual(user.email, email)
+        self.assertTrue(user.is_staff)
+
+    def test_create_user_is_active(self):
+        """Check is_active attribute is respected"""
+        email = 'normal@normal.com'
+        user = User.objects.create_user(email, is_active=False)
+        self.assertEqual(user.email, email)
+        self.assertFalse(user.is_active)
+
+    def test_username_keyword_raises_warning(self):
+        """Remind dev that username doesn't exist on model"""
+        error = ('The Improved User model does not have a username; '
+                 'it uses only email')
+        with self.assertRaisesMessage(ValueError, error):
+            User.objects.create_user(
+                username='whoops',
+                email='test@test.com',
+                password='test',
+            )
+        with self.assertRaisesMessage(ValueError, error):
+            User.objects.create_superuser(
+                username='whoops',
+                email='test@test.com',
+                password='test',
+            )
+
+    def test_create_super_user_raises_error_on_false_is_superuser(self):
+        """Warn developer when creating superuse without is_superuser"""
+        error = 'Superuser must have is_superuser=True.'
+        with self.assertRaisesMessage(ValueError, error):
+            User.objects.create_superuser(
+                email='test@test.com',
+                password='test',
+                is_superuser=False,
+            )
+
+    def test_create_superuser_raises_error_on_false_is_staff(self):
+        """Warn developer when creating superuse without is_staff"""
+        error = 'Superuser must have is_staff=True.'
+        with self.assertRaisesMessage(ValueError, error):
+            User.objects.create_superuser(
+                email='test@test.com',
+                password='test',
+                is_staff=False,
+            )
+
+    def test_make_random_password(self):
+        """Test manager make_random_password method"""
+        allowed_chars = 'abcdefg'
+        password = UserManager().make_random_password(5, allowed_chars)
+        self.assertEqual(len(password), 5)
+        for char in password:
+            self.assertIn(char, allowed_chars)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,9 @@
 """Test Improved User Model"""
 from types import MethodType
+from unittest import skipUnless
 from unittest.mock import patch
 
+from django import VERSION as DjangoVersion
 from django.contrib.auth.hashers import get_hasher
 from django.core import mail
 from django.test import TestCase
@@ -82,6 +84,9 @@ class UserModelTestCase(TestCase):
         user.clean()
         self.assertEqual(user.email, 'foo@bar.com')
 
+    @skipUnless(
+        DjangoVersion >= (1, 9),
+        'Password strength checks not available on Django 1.8')
     def test_user_double_save(self):
         """
         Calling user.save() twice should trigger password_changed() once.
@@ -97,6 +102,9 @@ class UserModelTestCase(TestCase):
             user.save()
             self.assertEqual(pw_changed.call_count, 1)
 
+    @skipUnless(
+        DjangoVersion >= (1, 9),
+        'Password strength checks not available on Django 1.8')
     def test_check_password_upgrade(self):
         """
         password_changed() shouldn't be called if User.check_password()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,7 +58,8 @@ class UserModelTestCase(TestCase):
             subject='Subject here',
             message='This is a message',
             from_email='from@domain.com',
-            **kwargs,
+            # TODO: when Py3.4 removed, add comma, remove C815 exception
+            **kwargs  # noqa: C815
         )
         self.assertEqual(len(mail.outbox), 1)
         message = mail.outbox[0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,42 +1,50 @@
+"""Test Improved User Model"""
+from types import MethodType
+from unittest.mock import patch
+
+from django.contrib.auth.hashers import get_hasher
 from django.core import mail
 from django.test import TestCase
 
-from improved_user.models import AbstractUser, User, UserManager
+from improved_user.models import User
 
 
-class UserManagerTestCase(TestCase):
+class UserModelTestCase(TestCase):
+    """Improve User Model Test Suite"""
 
-    def test_create_user(self):
-        email_lowercase = 'normal@normal.com'
-        user = User.objects.create_user(email_lowercase)
-        self.assertEqual(user.email, email_lowercase)
-        self.assertFalse(user.has_usable_password())
-
-    def test_create_user_email_domain_normalize_rfc3696(self):
-        # According to  http://tools.ietf.org/html/rfc3696#section-3
-        # the "@" symbol can be part of the local part of an email address
-        returned = UserManager.normalize_email(r'Abc\@DEF@EXAMPLE.com')
-        self.assertEqual(returned, r'Abc\@DEF@example.com')
-
-    def test_create_user_email_domain_normalize(self):
-        returned = UserManager.normalize_email('normal@DOMAIN.COM')
-        self.assertEqual(returned, 'normal@domain.com')
-
-    def test_create_user_email_domain_normalize_with_whitespace(self):
-        returned = UserManager.normalize_email('email\ with_whitespace@D.COM')
-        self.assertEqual(returned, 'email\ with_whitespace@d.com')
-
-    def test_empty_username(self):
-        self.assertRaisesMessage(
-            ValueError,
-            'An email address must be provided.',
-            User.objects.create_user,
-            email='',
+    def test_fields_and_attributes(self):
+        """Ensure the model has the fields and attributes we expect"""
+        expected_fields = (
+            'id',
+            'password',
+            'last_login',
+            'is_superuser',
+            'full_name',
+            'short_name',
+            'is_staff',
+            'is_active',
+            'date_joined',
+            'email',
+            'groups',
+            'user_permissions',
         )
+        user_fields = [field.name for field in User._meta.get_fields()]
+        for field in expected_fields:
+            with self.subTest(field=field):
+                self.assertIn(field, user_fields)
+        # Pre-empt Django check auth.E001
+        self.assertTrue(isinstance(User.REQUIRED_FIELDS, (list, tuple)))
+        # Pre-empt Django check auth.E002
+        self.assertNotIn(User.USERNAME_FIELD, User.REQUIRED_FIELDS)
+        # Pre-empt Django check auth.E003
+        self.assertIs(User._meta.get_field(User.USERNAME_FIELD).unique, True)
+        # Pre-empt Django check auth.C009
+        self.assertFalse(isinstance(User.is_anonymous, MethodType))
+        # Pre-empt Django check auth.C010
+        self.assertFalse(isinstance(User.is_authenticated, MethodType))
 
-
-class AbstractUserTestCase(TestCase):
     def test_email_user(self):
+        """Send Email to User via method"""
         # valid send_mail parameters
         kwargs = {
             'fail_silently': False,
@@ -45,17 +53,70 @@ class AbstractUserTestCase(TestCase):
             'connection': None,
             'html_message': None,
         }
-        abstract_user = AbstractUser(email='foo@bar.com')
-        abstract_user.email_user(
+        user = User(email='foo@bar.com')
+        user.email_user(
             subject='Subject here',
             message='This is a message',
             from_email='from@domain.com',
-            **kwargs)
-        # Test that one message has been sent.
+            **kwargs,
+        )
         self.assertEqual(len(mail.outbox), 1)
-        # Verify that test email contains the correct attributes:
         message = mail.outbox[0]
         self.assertEqual(message.subject, 'Subject here')
         self.assertEqual(message.body, 'This is a message')
         self.assertEqual(message.from_email, 'from@domain.com')
-        self.assertEqual(message.to, [abstract_user.email])
+        self.assertEqual(message.to, [user.email])
+
+    def test_last_login_default(self):
+        """Check last login not set upon creation"""
+        user1 = User.objects.create(email='test1@example.com')
+        self.assertIsNone(user1.last_login)
+
+        user2 = User.objects.create(email='test2@example.com')
+        self.assertIsNone(user2.last_login)
+
+    def test_user_clean_normalize_email(self):
+        """User email/username is normalized upon creation"""
+        user = User(email='foo@BAR.com', password='foo')
+        user.clean()
+        self.assertEqual(user.email, 'foo@bar.com')
+
+    def test_user_double_save(self):
+        """
+        Calling user.save() twice should trigger password_changed() once.
+        """
+        user = User.objects.create_user(
+            email='test@example.com', password='foo')
+        user.set_password('bar')
+        with patch(
+            'django.contrib.auth.password_validation.password_changed',
+        ) as pw_changed:
+            user.save()
+            self.assertEqual(pw_changed.call_count, 1)
+            user.save()
+            self.assertEqual(pw_changed.call_count, 1)
+
+    def test_check_password_upgrade(self):
+        """
+        password_changed() shouldn't be called if User.check_password()
+        triggers a hash iteration upgrade.
+        """
+        user = User.objects.create_user(
+            email='test@example.com', password='foo')
+        initial_password = user.password
+        self.assertTrue(user.check_password('foo'))
+        hasher = get_hasher('default')
+        self.assertEqual('pbkdf2_sha256', hasher.algorithm)
+
+        old_iterations = hasher.iterations
+        try:
+            # Upgrade the password iterations
+            hasher.iterations = old_iterations + 1
+            with patch(
+                'django.contrib.auth.password_validation.password_changed',
+            ) as pw_changed:
+                user.check_password('foo')
+                self.assertEqual(pw_changed.call_count, 0)
+            self.assertNotEqual(initial_password, user.password)
+        finally:
+            hasher.iterations = old_iterations

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,34 @@
+"""Test Signal Handling"""
+from django.db.models.signals import post_save
+from django.test import TestCase
+
+from improved_user.models import User
+
+
+class TestCreateSuperUserSignals(TestCase):
+    """Simple test case for ticket #20541"""
+
+    # pylint: disable=unused-argument
+    def post_save_listener(self, *args, **kwargs):
+        """Utility function to note when signal sent"""
+        self.signals_count += 1
+    # pylint: enable=unused-argument
+
+    def setUp(self):
+        """Connect function above to postsave User model signal"""
+        self.signals_count = 0
+        post_save.connect(self.post_save_listener, sender=User)
+
+    def tearDown(self):
+        """Connect utility function from postsave"""
+        post_save.disconnect(self.post_save_listener, sender=User)
+
+    def test_create_user(self):
+        """Test User Creation"""
+        User.objects.create_user('mail@example.com')
+        self.assertEqual(self.signals_count, 1)
+
+    def test_create_superuser(self):
+        """Test Super User Creation"""
+        User.objects.create_superuser('mail@example.com', 'password')
+        self.assertEqual(self.signals_count, 1)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,18 @@
+"""Test URLs for auth admins"""
+from django.conf.urls import url
+from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin
+from django.contrib.auth.models import Group
+from django.contrib.auth.urls import urlpatterns
+
+from improved_user.admin import UserAdmin
+from improved_user.models import User
+
+# Create a silo'd admin site for just the user/group admins.
+SITE = admin.AdminSite(name='auth_test_admin')
+SITE.register(User, UserAdmin)
+SITE.register(Group, GroupAdmin)
+
+urlpatterns += [
+    url(r'^admin/', SITE.urls),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
+       lint,pylint,pkgcheck,
        {py34,py35}-django{18,110}
        {py34,py35,py36}-django111,
-       {py34,py35,py36}-djangomaster,
-       pkgcheck,lint,pylint
+       {py34,py35,py36}-djangomaster
 
 [testenv:pkgcheck]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 skip_install = true
 commands =
-    pylint src setup.py runtests.py
+    pylint src tests setup.py runtests.py
 
 [testenv]
 commands =


### PR DESCRIPTION
Using the master branch of Django (current release 1.11.3), I've gone through all of the tests and checks of the contrib auth module. I've ported over tests that either (1) test behavior of our (very similar) code or (2) tests that ensure parity of behavior and security when using this package. The goal is to provide a User that feels like Django's with only minor tweaks.

The goal was to be overly aggressive. There are likely tests that we could prune from this commit. However, the goal was to ensure that there were are no tests in Django that do not exist here that could benefit this package. Of course, this is detailed oriented and a little fiddly, and I am only human, so there's bound to be something I missed. 