### PR TITLE
Fix #25 - User Manager doesn't set last_login

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,4 +4,5 @@ AUTHORS
 
 - Andrew Pinkham http://andrewsforge.com
 - Jim Illback jimillback01@gmail.com
+- Josh Schneier https://github.com/jschneier
 - Russell Keith-Magee http://cecinestpasun.com

--- a/src/improved_user/models.py
+++ b/src/improved_user/models.py
@@ -20,11 +20,10 @@ class UserManager(BaseUserManager):
             raise ValueError(
                 'The Improved User model does not have a username; '
                 'it uses only email')
-        now = timezone.now()
         user = self.model(
             email=self.normalize_email(email),
             is_staff=is_staff, is_superuser=is_superuser,
-            last_login=now, date_joined=now, **extra_fields)
+            **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,4 +1,6 @@
 """Test User model manager"""
+from datetime import datetime
+
 from django.test import TestCase
 
 from improved_user.models import User, UserManager
@@ -93,3 +95,24 @@ class UserManagerTestCase(TestCase):
         self.assertEqual(len(password), 5)
         for char in password:
             self.assertIn(char, allowed_chars)
+
+    def test_last_login_is_none(self):
+        """Check that last login is unset when created
+
+        https://github.com/jambonsw/django-improved-user/issues/25
+        """
+        user1 = User.objects.create_user('hello@jambonsw.com', 'password1')
+        self.assertIsNone(user1.last_login)
+
+        user2 = User.objects.create_superuser('clark@kent.com', 'password1')
+        self.assertIsNone(user2.last_login)
+
+    def test_date_joined_default(self):
+        """Check date joined set upon creation"""
+        user1 = User.objects.create_user('hello@jambonsw.com', 'password1')
+        self.assertIsNotNone(user1.date_joined)
+        self.assertIsInstance(user1.date_joined, datetime)
+
+        user2 = User.objects.create_superuser('clark@kent.com', 'password1')
+        self.assertIsNotNone(user2.date_joined)
+        self.assertIsInstance(user2.date_joined, datetime)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 """Test Improved User Model"""
+from datetime import datetime
 from types import MethodType
 from unittest import skipUnless
 from unittest.mock import patch
@@ -77,6 +78,16 @@ class UserModelTestCase(TestCase):
 
         user2 = User.objects.create(email='test2@example.com')
         self.assertIsNone(user2.last_login)
+
+    def test_date_joined_default(self):
+        """Check date joined set upon creation"""
+        user1 = User.objects.create(email='test1@example.com')
+        self.assertIsNotNone(user1.date_joined)
+        self.assertIsInstance(user1.date_joined, datetime)
+
+        user2 = User.objects.create(email='test2@example.com')
+        self.assertIsNotNone(user2.date_joined)
+        self.assertIsInstance(user2.date_joined, datetime)
 
     def test_user_clean_normalize_email(self):
         """User email/username is normalized upon creation"""


### PR DESCRIPTION
Ensure that last_login and date_joined defaults are properly set in User Model, and ensure that User Manager does not override the defaults.

Thanks to @jschneier for reporting the issue.

<!--

Thank you for submitting a pull request (PR)! :tada::+1:

Remember that this is a volunteer-driven project. To help review your PR, please read the following guidelines.

If you are changing documentation, please provide a quick summary and the motivation.

If you are changing code, please refer to the issue this PR proposes to fix, and explain your solution. If you have not opened an issue, you must do so first. Ensure the title of the PR starts with Fix #X where X is the issue number.

If you are changing code, both documentation and testing should be updated. For all linting and testing tools used by the package, please see the Contributing section of the documentation.

Your commits will be squashed during the merge. Small commits are encouraged. Rebasing your commits to make reviewing your changes easier is encouraged.

-->
