### PR TITLE
Prepare for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 - DJANGO='django>=1.8,<1.9'
 - DJANGO='django>=1.10,<1.11'
 - DJANGO='django>=1.11,<1.12'
+- DJANGO='django>=2.0a,<2.1'
 - DJANGO=https://github.com/django/django/archive/master.tar.gz
 matrix:
   exclude:
@@ -25,13 +26,15 @@ matrix:
     env: DJANGO='django>=1.8,<1.9'
   - python: 3.7-dev
     env: DJANGO='django>=1.10,<1.11'
+  - python: 3.7-dev
+    env: DJANGO='django>=1.11,<1.12'
   allow_failures:
   - python: 3.5
     env: DJANGO=https://github.com/django/django/archive/master.tar.gz
   - python: 3.6
     env: DJANGO=https://github.com/django/django/archive/master.tar.gz
   - python: 3.7-dev
-    env: DJANGO='django>=1.11,<1.12'
+    env: DJANGO='django>=2.0a,<2.1'
   - python: 3.7-dev
     env: DJANGO=https://github.com/django/django/archive/master.tar.gz
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ cache:
 - '%LOCALAPPDATA%\pip\Cache'
 
 image:
-- Visual Studio 2015
 - Visual Studio 2017
 
 environment:
@@ -24,6 +23,9 @@ environment:
   - PYTHON: "C:\\Python34"
     DJANGO: "django>=1.11,<1.12"
 
+  - PYTHON: "C:\\Python34"
+    DJANGO: "django>=2.0a,<2.1"
+
   - PYTHON: "C:\\Python35"
     DJANGO: "django>=1.8,<1.9"
 
@@ -33,8 +35,15 @@ environment:
   - PYTHON: "C:\\Python35"
     DJANGO: "django>=1.11,<1.12"
 
+  - PYTHON: "C:\\Python35"
+    DJANGO: "django>=2.0a,<2.1"
+
   - PYTHON: "C:\\Python36"
     DJANGO: "django>=1.11,<1.12"
+
+  - PYTHON: "C:\\Python36"
+    DJANGO: "django>=2.0a,<2.1"
+
 
 init:
 - echo "%DJANGO%"

--- a/docs/quickstart_contrib.rst
+++ b/docs/quickstart_contrib.rst
@@ -12,6 +12,7 @@ To test the package, start by installing the current package locally.
 
 .. code:: console
 
+    $ pip install -r requirements.txt
     $ python setup.py develop
 
 To run the test suite on a single version of Django (assuming you have a

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ flake8-quotes==0.11.0
 flake8==3.4.1
 Pygments==2.2.0
 pylint-django==0.7.2
-pylint==1.7.2
+pylint==1.7.4
 python-dateutil==2.6.1
 setuptools==36.5.0
 sphinx-rtd-theme==0.2.4
 Sphinx==1.6.4
-tox==2.8.2
+tox==2.9.1
 twine==1.9.1
 wheel==0.30.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ inline-quotes = single
 max-complexity = 10
 max-line-length = 79
 [metadata]
-description-file = README.md
+description-file = README.rst
 [pep8]
 # https://pep8.readthedocs.org/en/latest/
 # W503 raised if operators are after line break

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     install_requires=[
-        'django>=1.8',
+        'django>=1.8,!=1.9.*',
     ],
     extras_require={
         'factory': [

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -13,6 +13,7 @@ from improved_user.admin import UserAdmin
 from improved_user.forms import UserChangeForm, UserCreationForm
 from improved_user.models import User
 
+# TODO: remove conditional import when Dj 1.8 dropped
 # pylint: disable=ungrouped-imports
 try:
     from django.urls import reverse

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -62,5 +62,4 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
                 email=invalid_username,
                 short_name='Joe',
                 full_name='Joe Smith',
-                password='password1!',
                 stdout=new_io)

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,13 +1,73 @@
 """Test User model management commands"""
+import builtins
 from io import StringIO
 
+from django import VERSION as DjangoVersion
+from django.contrib.auth.management.commands import createsuperuser
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from improved_user.models import User
 
 
+# pylint: disable=missing-docstring,too-few-public-methods
+def mock_inputs(inputs):
+    """
+    Decorator to temporarily replace input/getpass to allow interactive
+    createsuperuser.
+    """
+    def inner(test_func):
+        def wrapped(*args):
+            class MockGetPass:
+                # pylint: disable=unused-argument
+                @staticmethod
+                def getpass(prompt=b'Password: ', stream=None):
+                    if callable(inputs['password']):
+                        return inputs['password']()
+                    return inputs['password']
+                # pylint: enable=unused-argument
+
+            def mock_input(prompt):
+                assert '__proxy__' not in prompt
+                response = ''
+                for key, val in inputs.items():
+                    if key in prompt.lower():
+                        if callable(val):
+                            response = val()
+                        else:
+                            response = val
+                        break
+                return response
+
+            old_getpass = createsuperuser.getpass
+            old_input = builtins.input
+            createsuperuser.getpass = MockGetPass
+            builtins.input = mock_input
+            try:
+                test_func(*args)
+            finally:
+                createsuperuser.getpass = old_getpass
+                builtins.input = old_input
+        return wrapped
+    return inner
+
+
+class MockTTY:
+    """
+    A fake stdin object that pretends to be a TTY to be used in conjunction
+    with mock_inputs.
+    """
+    def isatty(self):  # pylint: disable=no-self-use
+        return True
+# pylint: enable=missing-docstring,too-few-public-methods
+
+
+@override_settings(
+    AUTH_PASSWORD_VALIDATORS=[{
+        'NAME':
+            'django.contrib.auth.password_validation.'
+            'NumericPasswordValidator'}])
 class CreatesuperuserManagementCommandTestCase(TestCase):
     """Test createsuperuser management command"""
 
@@ -63,3 +123,42 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
                 short_name='Joe',
                 full_name='Joe Smith',
                 stdout=new_io)
+
+    def test_password_validation(self):
+        """Creation should fail if the password fails validation."""
+        new_io = StringIO()
+
+        index = [0]
+
+        # Returns '1234567890' the first two times it is called, then
+        # 'password' subsequently.
+        def bad_then_good_password():
+            """Simulate user input on terminal"""
+            index[0] += 1
+            if index[0] <= 2:
+                return '1234567890'
+            return 'password'
+
+        @mock_inputs({
+            'password': bad_then_good_password,
+        })
+        def test(self):
+            """The actual test function; run with multiple inputs"""
+            call_command(
+                'createsuperuser',
+                email='hello@jambonsw.com',
+                full_name='Joe Smith',
+                interactive=True,
+                short_name='Joe',
+                stderr=new_io,
+                stdin=MockTTY(),
+                stdout=new_io,
+            )
+            if DjangoVersion >= (1, 9):
+                expected_out = ('This password is entirely numeric.\n'
+                                'Superuser created successfully.')
+            else:
+                expected_out = 'Superuser created successfully.'
+            self.assertEqual(new_io.getvalue().strip(), expected_out)
+
+        test(self)

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ envlist =
        py36-pylint-django111,
        py36-pkgcheck-django111,
        py36-docs-django111,
-       {py34,py35}-django{18,110,111}-unit
+       {py34,py35}-django{18,110,111,20}-unit
        {py35}-django{master}-unit,
-       {py36}-django{111,master}-unit,
-       {py34,py35}-django{18,110,111}-integration
+       {py36}-django{111,20,master}-unit,
+       {py34,py35}-django{18,110,111,20}-integration
        {py35}-django{master}-integration,
-       {py36}-django{111,master}-integration,
+       {py36}-django{111,20,master}-integration,
 
 [testenv]
 changedir =
@@ -28,6 +28,7 @@ deps =
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0a,<2.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
This is not a full upgrade to Django 2.0 (linters still run on Django 1.11, for instance), but it is preparation in anticipation of the new version.