### PR TITLE
Update documentation build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
 install:
 - pip install -r requirements.txt
 - pip install -r example_project/requirements.txt
+- if [[ `python -V | grep -c -e 3.5` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then pip install -r doc-requirements.txt ; fi
 - pip install "$DJANGO"
 - pip install codecov
 - ./setup.py develop
@@ -55,7 +56,7 @@ script:
 - cd example_project
 - ./manage.py test
 - cd ../docs
-- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then sphinx-build -W -b html -d _build/doctrees . _build/html ; fi
+- if [[ `python -V | grep -c -e 3.5` -eq 1 && "$DJANGO" == 'django>=1.11,<1.12' ]]; then sphinx-build -W -b html -d _build/doctrees . _build/html ; fi
 - cd ..  # for coverage reports
 after_success:
 # coverage is run in parallel, so it is necessary to combine the reports

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include .pyup.yml
 include .travis.yml
 include LICENSE
 include appveyor.yml
+include doc-requirements.txt
 include requirements.txt
 include runtests.py
 include setup.cfg

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,7 @@
+Django>=1.11,<2.0
+factory_boy==2.9.2
+Faker==0.8.4
+Pygments==2.2.0
+python-dateutil==2.6.1
+sphinx-rtd-theme==0.2.4
+Sphinx==1.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ pylint-django==0.7.2
 pylint==1.7.4
 python-dateutil==2.6.1
 setuptools==36.5.0
-sphinx-rtd-theme==0.2.4
-Sphinx==1.6.4
 tox==2.9.1
 twine==1.9.1
 wheel==0.30.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-       py36-lint-django111,
-       py36-pylint-django111,
-       py36-pkgcheck-django111,
-       py36-docs-django111,
+       py36-django111-lint,
+       py36-django111-pylint,
+       py36-django111-pkgcheck,
+       py35-docs,
        {py34,py35}-django{18,110,111,20}-unit
        {py35}-django{master}-unit,
        {py36}-django{111,20,master}-unit,
@@ -18,12 +18,14 @@ changedir =
     unit: {toxinidir}
 skip_install =
     {lint,pkgcheck,pylint}: true
-extras = factory
+extras =
+    {integration,pylint,unit}: factory
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     {unit,integration}: PYTHONWARNINGS=once
 deps =
-    -r{toxinidir}/requirements.txt
+    {integration,lint,pkgcheck,pylint,unit}: -r{toxinidir}/requirements.txt
+    docs: -r{toxinidir}/doc-requirements.txt
     {integration,pylint}: -r{toxinidir}/example_project/requirements.txt
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
ReadTheDocs runs on Python 3.5. We therefore switch the Tox and Travis
documentation tests to run on the same Python versions.

We furthermore create a dedicated requirements file for documentation
building to specify the latest version of Django. This permits the
existing requirements file for development to omit Django.