### PR TITLE
Simplify installation instructions

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,15 +22,12 @@ In a Terminal, use :code:`pip` to install the package from `PyPI`_.
 
 If you intend to use the :class:`~improved_user.factories.UserFactory`
 provided by the package to allow for testing with |factory_boy|_, you
-can specify so during install.
+can either install |factory_boy| separately, or use the modified installation
+below.
 
 .. code:: console
 
     $ pip install django-improved-user[factory]
-
-If you use the first command but wish to use the
-:class:`~improved_user.factories.UserFactory`, you will need to install
-|factory_boy|_ yourself.
 
 .. _PyPI: https://pypi.org/project/django-improved-user/
 .. _factory_boy: https://github.com/FactoryBoy/factory_boy

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,20 +14,22 @@ See :doc:`select_configuration_method` for an overview of options and tradeoffs.
 Installation
 ************
 
-In a Terminal, use :code:`pip` to install the package from `PyPI`_.
+In a Terminal, use :code:`pip` to install the package from `PyPI`_. 
+To use the :class:`~improved_user.factories.UserFactory` provided 
+by the package to allow for testing with |factory_boy|_, include it
+in the installation.
+
+.. code:: console
+
+    $ pip install django-improved-user[factory]
+
+If |factory_boy|_ is unnecessary, it can be omitted by installing normally.
 
 .. code:: console
 
     $ pip install django-improved-user
 
-If you intend to use the :class:`~improved_user.factories.UserFactory`
-provided by the package to allow for testing with |factory_boy|_, you
-can either install |factory_boy| separately, or use the modified installation
-below.
 
-.. code:: console
-
-    $ pip install django-improved-user[factory]
 
 .. _PyPI: https://pypi.org/project/django-improved-user/
 .. _factory_boy: https://github.com/FactoryBoy/factory_boy


### PR DESCRIPTION
As we discussed previously, this proposed adjustment prevents an unwieldy redirect of the reader's attention to a prior command by unifying the discussion of both separate installation and integrated installation into the paragraph between the two shell code blocks. This also makes the document more concise.