### PR TITLE
✨ Improve Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
           - "Type: Dependency Upgrade"
       ignore:
           - dependency-name: "django"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          # Check for updates to GitHub Actions every weekday
+          interval: "daily"
+          time: "06:50"
+          timezone: "America/New_York"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,5 @@ updates:
       labels:
           - "Status: Ready for Review"
           - "Type: Dependency Upgrade"
+      ignore:
+          - dependency-name: "django"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-astroid==2.8.4
+astroid==2.9.0
 bumpversion==0.6.0
 check-manifest==0.47
-coverage==6.1.1
+coverage==6.2
 docutils==0.18.1
 factory_boy==3.2.1
 Faker==10.0.0
 flit==3.5.1
 Pygments==2.10.0
-pylint==2.11.1
+pylint==2.12.2
 pylint-django==2.4.4
 python-dateutil==2.8.2
 tox==3.24.4


### PR DESCRIPTION
This PR tells Dependabot:

- to ignore updates to Django (the package uses a range based on Django LTS - the package should not point to the latest Django version, or it will force developers using this package to upgrade Django as well);
- to update Github actions as well as Python packages.

Additionally, this PR updates dependencies to help Dependabot.