### PR TITLE
❗️ Upgrade Github Actions

### DIFF
--- a/.github/workflows/define-labels.yml
+++ b/.github/workflows/define-labels.yml
@@ -5,9 +5,9 @@ on:
             - development
 jobs:
     define:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: micnncim/action-label-syncer@v1.3.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,32 +3,38 @@ name: Publish package to PyPI
 on:
     push:
         tags:
-            - "v2.*"
+            - "v*"
 
 jobs:
     build:
         name: Build package
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
+        environment: publish
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Build sdist
               run: pipx run build --sdist --wheel
 
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   path: dist/*
 
-    upload_pypi:
+    publish:
+        name: Upload release to PyPI
         needs: [build]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
+        environment:
+            name: publish
+            url: https://pypi.org/p/django-improved-user/
+        permissions:
+            id-token: write
         steps:
-            - uses: actions/download-artifact@v2
+            - name: Download artifact from build step
+              uses: actions/download-artifact@v4
               with:
                   name: artifact
                   path: dist
 
-            - uses: pypa/gh-action-pypi-publish@v1.4.2
-              with:
-                  user: __token__
-                  password: ${{ secrets.pypi_password }}
+            - name: Publish to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-20.04, windows-2022]
                 # Django LTS versions & latest version only
                 django-version: ["2.2", "3.2"]
                 project: ["extension", "integration", "replacement"]
@@ -25,10 +25,10 @@ jobs:
                       project: "integration"
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.9"
 
@@ -40,7 +40,7 @@ jobs:
               run: echo "::set-output name=dir::$(pip cache dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.pip-cache.outputs.dir }}
                   key:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,15 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-20.04, windows-2022]
                 python-version: ["3.6", "3.7", "3.8", "3.9"]
                 django-version: ["2.2", "3.0", "3.1", "3.2"]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
               run: echo "::set-output name=dir::$(pip cache dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.pip-cache.outputs.dir }}
                   key:
@@ -65,7 +65,9 @@ jobs:
                   coverage report
                   coverage xml
 
-            - uses: codecov/codecov-action@v2
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v4
               with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
                   fail_ci_if_error: true
                   verbose: true


### PR DESCRIPTION
Enable Github actions to run again.

- pin OS to specific versions
- upgrade actions to latest versions
- publish to PyPI using Trusted Publisher Management

NB: publish environment was manually defined in Github for security purposes, following PyPa's recommendation.
