### PR TITLE
✏️ Update documentation links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -185,7 +185,7 @@ Your First Documentation Contribution
 
     — `Mike Pope`_
 
-.. _Mike Pope: http://www.mikepope.com/blog/DisplayBlog.aspx?permalink=1680
+.. _Mike Pope: https://www.mikepope.com/blog/DisplayBlog.aspx?permalink=1680
 
 Documentation is crucial, and I am thrilled to get your help writing it!
 
@@ -240,5 +240,5 @@ Congratulations on opening a pull request! 🎉
 .. _Github issue tracker: https://github.com/jambonrose/django-improved-user/issues
 .. _Github: https://github.com/jambonrose/django-improved-user
 .. _primer on rst: http://www.sphinx-doc.org/en/stable/rest.html#rst-primer
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: http://www.sphinx-doc.org/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,7 +25,7 @@ are expected to uphold this code.
 
 Please be respectful to other developers.
 
-.. _Code of Conduct: https://github.com/jambonsw/django-improved-user/blob/development/CODE_OF_CONDUCT.md
+.. _Code of Conduct: https://github.com/jambonrose/django-improved-user/blob/development/CODE_OF_CONDUCT.md
 
 Types of Contributions
 ----------------------
@@ -237,8 +237,8 @@ review your code.
 
 Congratulations on opening a pull request! 🎉
 
-.. _Github issue tracker: https://github.com/jambonsw/django-improved-user/issues
-.. _Github: https://github.com/jambonsw/django-improved-user
+.. _Github issue tracker: https://github.com/jambonrose/django-improved-user/issues
+.. _Github: https://github.com/jambonrose/django-improved-user
 .. _primer on rst: http://www.sphinx-doc.org/en/stable/rest.html#rst-primer
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://www.sphinx-doc.org/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,8 +23,8 @@ Next Release
     - Upgrade development & documentation dependencies
     - Use flit to build/release sdist instead of setup.py
 
-.. _#117: https://github.com/jambonsw/django-improved-user/pull/117
-.. _#118: https://github.com/jambonsw/django-improved-user/issues/118
+.. _#117: https://github.com/jambonrose/django-improved-user/pull/117
+.. _#118: https://github.com/jambonrose/django-improved-user/issues/118
 
 1.0.1 (2020-02-16)
 ------------------
@@ -49,13 +49,13 @@ Next Release
   the project). Add documentation/tutorial on subject. (`#46`_)
 - Django 2.0, 2.1 compatibility. (`#43`_, `#93`_)
 
-.. _#36: https://github.com/jambonsw/django-improved-user/issues/36
-.. _#43: https://github.com/jambonsw/django-improved-user/pull/43
-.. _#46: https://github.com/jambonsw/django-improved-user/pull/46
-.. _#49: https://github.com/jambonsw/django-improved-user/issues/49
-.. _#50: https://github.com/jambonsw/django-improved-user/pull/50
-.. _#93: https://github.com/jambonsw/django-improved-user/pull/93
-.. _#96: https://github.com/jambonsw/django-improved-user/pull/96
+.. _#36: https://github.com/jambonrose/django-improved-user/issues/36
+.. _#43: https://github.com/jambonrose/django-improved-user/pull/43
+.. _#46: https://github.com/jambonrose/django-improved-user/pull/46
+.. _#49: https://github.com/jambonrose/django-improved-user/issues/49
+.. _#50: https://github.com/jambonrose/django-improved-user/pull/50
+.. _#93: https://github.com/jambonrose/django-improved-user/pull/93
+.. _#96: https://github.com/jambonrose/django-improved-user/pull/96
 
 
 0.5.3 (2017-08-29)
@@ -65,7 +65,7 @@ Next Release
 - Write documentation about why and how the project was built. (`#34`_)
 - Add section about contributing documentation. (`#34`_)
 
-.. _#34: https://github.com/jambonsw/django-improved-user/pull/34
+.. _#34: https://github.com/jambonrose/django-improved-user/pull/34
 
 0.5.2 (2017-08-27)
 ------------------
@@ -86,7 +86,7 @@ Next Release
   `rtfd/readthedocs.org#2032`_ for more information. (`#31`_)
 
 .. _rtfd/readthedocs.org#2032: https://github.com/rtfd/readthedocs.org/issues/2032
-.. _#31: https://github.com/jambonsw/django-improved-user/pull/31
+.. _#31: https://github.com/jambonrose/django-improved-user/pull/31
 
 0.5.0 (2017-08-26)
 ------------------
@@ -103,11 +103,11 @@ Next Release
   of new users at creation time. Reported in `#25`_, fixed in `#27`_
   (``last_login`` is ``None`` until the user actually logs in).
 
-.. _#25: https://github.com/jambonsw/django-improved-user/issues/25
-.. _#26: https://github.com/jambonsw/django-improved-user/pull/26
-.. _#27: https://github.com/jambonsw/django-improved-user/pull/27
-.. _#28: https://github.com/jambonsw/django-improved-user/pull/28
-.. _#29: https://github.com/jambonsw/django-improved-user/pull/29
+.. _#25: https://github.com/jambonrose/django-improved-user/issues/25
+.. _#26: https://github.com/jambonrose/django-improved-user/pull/26
+.. _#27: https://github.com/jambonrose/django-improved-user/pull/27
+.. _#28: https://github.com/jambonrose/django-improved-user/pull/28
+.. _#29: https://github.com/jambonrose/django-improved-user/pull/29
 
 0.4.0 (2017-08-14)
 ------------------
@@ -124,9 +124,9 @@ with v0.3.0 due to PR `#23`_
 - Change ``blank`` to ``True`` on ``short_name`` field of User model.
   (**Breaking change!** PR `#23`_).
 
-.. _#20: https://github.com/jambonsw/django-improved-user/pull/20
-.. _#22: https://github.com/jambonsw/django-improved-user/pull/22
-.. _#23: https://github.com/jambonsw/django-improved-user/pull/23
+.. _#20: https://github.com/jambonrose/django-improved-user/pull/20
+.. _#22: https://github.com/jambonrose/django-improved-user/pull/22
+.. _#23: https://github.com/jambonrose/django-improved-user/pull/23
 
 0.3.0 (2017-08-10)
 ------------------
@@ -151,8 +151,8 @@ with v0.3.0 due to PR `#23`_
   in all versions of Django (was not working in Django 1.9+) (PR `#18`_)
 - Bugfix: Runtests correctly handles test specification (PR `#18`_)
 
-.. _#16: https://github.com/jambonsw/django-improved-user/pull/16
-.. _#18: https://github.com/jambonsw/django-improved-user/pull/18
+.. _#16: https://github.com/jambonrose/django-improved-user/pull/16
+.. _#18: https://github.com/jambonrose/django-improved-user/pull/18
 
 0.2.0 (2017-07-30)
 ------------------
@@ -171,12 +171,12 @@ with v0.3.0 due to PR `#23`_
   bumpversion package and a Makefile (PR `#15`_)
 - Add HISTORY.rst file to provide change log (PR `#15`_)
 
-.. _#9: https://github.com/jambonsw/django-improved-user/pull/9
-.. _#10: https://github.com/jambonsw/django-improved-user/pull/10
-.. _#11: https://github.com/jambonsw/django-improved-user/pull/11
-.. _#12: https://github.com/jambonsw/django-improved-user/pull/12
-.. _#13: https://github.com/jambonsw/django-improved-user/pull/13
-.. _#15: https://github.com/jambonsw/django-improved-user/pull/15
+.. _#9: https://github.com/jambonrose/django-improved-user/pull/9
+.. _#10: https://github.com/jambonrose/django-improved-user/pull/10
+.. _#11: https://github.com/jambonrose/django-improved-user/pull/11
+.. _#12: https://github.com/jambonrose/django-improved-user/pull/12
+.. _#13: https://github.com/jambonrose/django-improved-user/pull/13
+.. _#15: https://github.com/jambonrose/django-improved-user/pull/15
 
 0.1.1 (2017-06-28)
 ------------------
@@ -184,7 +184,7 @@ with v0.3.0 due to PR `#23`_
 - Fix metadata in setup.py for warehouse
   (see https://github.com/pypa/warehouse/issues/2155 and PR `#8`_)
 
-.. _#8: https://github.com/jambonsw/django-improved-user/pull/8
+.. _#8: https://github.com/jambonrose/django-improved-user/pull/8
 
 0.1.0 (2017-06-28)
 ------------------
@@ -198,9 +198,9 @@ with v0.3.0 due to PR `#23`_
 - Initial public release (PR `#7`_)
 - Use Simplified BSD License instead of Revised BSD License (`#7`_)
 
-.. _#5: https://github.com/jambonsw/django-improved-user/pull/5
-.. _#6: https://github.com/jambonsw/django-improved-user/pull/6
-.. _#7: https://github.com/jambonsw/django-improved-user/pull/7
+.. _#5: https://github.com/jambonrose/django-improved-user/pull/5
+.. _#6: https://github.com/jambonrose/django-improved-user/pull/6
+.. _#7: https://github.com/jambonrose/django-improved-user/pull/7
 
 0.0.1 (2016-10-26)
 ------------------
@@ -212,6 +212,6 @@ with v0.3.0 due to PR `#23`_
     - Python 3.4, 3.5, 3.6
     - Django 1.8 through 1.10 (PR `#3`_ and `#4`_)
 
-.. _#1: https://github.com/jambonsw/django-improved-user/pull/1
-.. _#3: https://github.com/jambonsw/django-improved-user/pull/3
-.. _#4: https://github.com/jambonsw/django-improved-user/pull/4
+.. _#1: https://github.com/jambonrose/django-improved-user/pull/1
+.. _#3: https://github.com/jambonrose/django-improved-user/pull/3
+.. _#4: https://github.com/jambonrose/django-improved-user/pull/4

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -85,7 +85,7 @@ Next Release
   are unable to build that version until v1.0.0 release. See
   `rtfd/readthedocs.org#2032`_ for more information. (`#31`_)
 
-.. _rtfd/readthedocs.org#2032: https://github.com/rtfd/readthedocs.org/issues/2032
+.. _rtfd/readthedocs.org#2032: https://github.com/readthedocs/readthedocs.org/issues/2032
 .. _#31: https://github.com/jambonrose/django-improved-user/pull/31
 
 0.5.0 (2017-08-26)
@@ -165,7 +165,7 @@ with v0.3.0 due to PR `#23`_
   Use flake8-commas and flake8-quotes to enhance flake8.
   Override default distutils check command to check package metadata.
   Use check-manifest to check contents of MANIFEST.in (PR `#11`_)
-- Integrate https://pyup.io/ into project (PR `#12`_)
+- Integrate pyup.io into project (PR `#12`_)
 - Upgrade flake8 to version 3.4.1 (PR `#13`_)
 - Make release and distribution less painful with
   bumpversion package and a Makefile (PR `#15`_)
@@ -182,7 +182,7 @@ with v0.3.0 due to PR `#23`_
 ------------------
 
 - Fix metadata in setup.py for warehouse
-  (see https://github.com/pypa/warehouse/issues/2155 and PR `#8`_)
+  (see https://github.com/pypi/warehouse/issues/2155 and PR `#8`_)
 
 .. _#8: https://github.com/jambonrose/django-improved-user/pull/8
 

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Tests: |Pre-commit| |Coverage|
 		:target: https://pypi.org/project/django-improved-user/
 		:alt: PyPI Version
 
-.. |Tag| image:: https://img.shields.io/github/tag/jambonsw/django-improved-user.svg
-		:target: https://github.com/jambonsw/django-improved-user/releases
+.. |Tag| image:: https://img.shields.io/github/tag/jambonrose/django-improved-user.svg
+		:target: https://github.com/jambonrose/django-improved-user/releases
 		:alt: Github Tag
 
 .. |StableDocs| image:: https://readthedocs.org/projects/django-improved-user/badge/?version=stable
@@ -26,7 +26,7 @@ Tests: |Pre-commit| |Coverage|
 		:target: https://pypi.org/project/django-improved-user/
 		:alt: Python Support
 
-.. |Django| image:: https://img.shields.io/badge/Django-1.8%2C%201.11%2C%202.0%2C%202.1-blue.svg
+.. |Django| image:: https://img.shields.io/badge/Django-2.2%2C%203.0%2C%203.1%2C%203.2-blue.svg
 		:target: https://pypi.org/project/django-improved-user/
 		:alt: Django Support
 
@@ -34,12 +34,12 @@ Tests: |Pre-commit| |Coverage|
 		:target: http://opensource.org/licenses/BSD-2-Clause
 		:alt: License
 
-.. |Pre-commit| image:: https://results.pre-commit.ci/badge/github/jambonsw/django-improved-user/development.svg
-		:target: https://results.pre-commit.ci/latest/github/jambonsw/django-improved-user/development
+.. |Pre-commit| image:: https://results.pre-commit.ci/badge/github/jambonrose/django-improved-user/development.svg
+		:target: https://results.pre-commit.ci/latest/github/jambonrose/django-improved-user/development
 		:alt: pre-commit.ci status
 
-.. |Coverage| image:: https://codecov.io/gh/jambonsw/django-improved-user/branch/development/graph/badge.svg
-		:target: https://codecov.io/gh/jambonsw/django-improved-user
+.. |Coverage| image:: https://codecov.io/gh/jambonrose/django-improved-user/branch/development/graph/badge.svg
+		:target: https://codecov.io/gh/jambonrose/django-improved-user
 		:alt: Coverage Status
 
 .. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Django Improved User"
-copyright = "2016-2021 JamBon Software"
+copyright = "2016-2024 Andrew Pinkham"
 author = "Russell Keith-Magee, Andrew Pinkham"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 """
 
 import inspect
+import re
 import sys
 from operator import attrgetter
 from os.path import abspath, join
@@ -298,3 +299,7 @@ texinfo_documents = [
         "Miscellaneous",
     ),
 ]
+
+# -- Linkcheck configuration -----------------------------------------------
+
+linkcheck_ignore = [re.compile(r'https://djangopackages\.org/.*')]

--- a/docs/email_warning.rst
+++ b/docs/email_warning.rst
@@ -30,5 +30,5 @@ can make this quite fast). These decisions and code are outside the
 scope of this project and we therefore do not provide any work on this
 front.
 
-.. _`RFC 5321`: https://tools.ietf.org/rfc/rfc5321.txt
+.. _`RFC 5321`: https://www.rfc-editor.org/rfc/rfc5321.txt
 .. _`cause obscure security issues`: https://www.schneier.com/blog/archives/2018/04/obscure_e-mail_.html

--- a/docs/rationale.rst
+++ b/docs/rationale.rst
@@ -42,7 +42,7 @@ allow for creation of new User models (notably, the
 
 We hope you find our work useful!
 
-.. _Andrew Pinkham: http://andrewsforge.com
+.. _Andrew Pinkham: https://andrewsforge.com
 .. _consulting experience: https://www.jambonsw.com
 .. _Django Unleashed: https://django-unleashed.com
 .. _his book, Django Unleashed: `Django Unleashed`_

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -30,7 +30,7 @@ see the reference documentation for these items below.
 Finally, the actual code on `Github`_ has three example projects that may
 be helpful if this documentation was not.
 
-.. _Github: https://github.com/jambonsw/django-improved-user
+.. _Github: https://github.com/jambonrose/django-improved-user
 
 *******************
 Reference Documents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ classifiers = [
 
 [project.urls]
 Documentation = "https://django-improved-user.rtfd.io"
-Source = "https://github.com/jambonsw/django-improved-user/"
-Tracker = "https://github.com/jambonsw/django-improved-user/issues"
+Source = "https://github.com/jambonrose/django-improved-user/"
+Tracker = "https://github.com/jambonrose/django-improved-user/issues"
 
 [project.optional-dependencies]
 factory = [


### PR DESCRIPTION
As Jambon Software is no longer operating, I have moved this repository to my personal account.

This updates all the links referring to the old repository.

This also replaces any broken link or redirecting link in the docs.