### PR TITLE
💥 Reduce compatibility to Django 4.2

### DIFF
--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -10,7 +10,6 @@ on:
           - src/**
           - tests/**
           - example_extension_project/**
-          - example_integration_project/**
           - example_replacement_project/**
 
 env:
@@ -22,16 +21,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-20.04, windows-2022]
-                # Django LTS versions & latest version only
-                django-version: ["2.2", "3.2", "4.2"]
-                project: ["extension", "integration", "replacement"]
-                exclude:
-                    # Django Registration 2 does not support Django above 2.2
-                    - django-version: "3.2"
-                      project: "integration"
-                    - django-version: "4.2"
-                      project: "integration"
+                os: [ubuntu-22.04, windows-2022]
+                django-version: ["4.2"]
+                project: ["extension", "replacement"]
 
         steps:
             - uses: actions/checkout@v4
@@ -39,7 +31,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.9"
+                  python-version: "3.12"
 
             - name: Upgrade pip
               run: python3 -m pip install -U distlib pip setuptools wheel

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,57 +17,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-20.04, windows-2022]
-                python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-                django-version: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2"]
-                exclude:
-                    # Django 2.2
-                    - django-version: "2.2"
-                      python-version: "3.10"
-                    - django-version: "2.2"
-                      python-version: "3.11"
-                    - django-version: "2.2"
-                      python-version: "3.12"
-                    # Django 3.0
-                    - django-version: "3.0"
-                      python-version: "3.10"
-                    - django-version: "3.0"
-                      python-version: "3.11"
-                    - django-version: "3.0"
-                      python-version: "3.12"
-                    # Django 3.1
-                    - django-version: "3.1"
-                      python-version: "3.10"
-                    - django-version: "3.1"
-                      python-version: "3.11"
-                    - django-version: "3.1"
-                      python-version: "3.12"
-                    # Django 3.2
-                    - django-version: "3.2"
-                      python-version: "3.11"
-                    - django-version: "3.2"
-                      python-version: "3.12"
-                    # Django 4.0
-                    - django-version: "4.0"
-                      python-version: "3.6"
-                    - django-version: "4.0"
-                      python-version: "3.7"
-                    - django-version: "4.0"
-                      python-version: "3.11"
-                    - django-version: "4.0"
-                      python-version: "3.12"
-                    # Django 4.1
-                    - django-version: "4.1"
-                      python-version: "3.6"
-                    - django-version: "4.1"
-                      python-version: "3.7"
-                    - django-version: "4.1"
-                      python-version: "3.12"
-                    # Django 4.2
-                    - django-version: "4.2"
-                      python-version: "3.6"
-                    - django-version: "4.2"
-                      python-version: "3.7"
+                os: [ubuntu-22.04, windows-2022]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+                django-version: ["4.2"]
 
         steps:
             - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,11 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py38-plus]
+    - repo: https://github.com/adamchainz/django-upgrade
+      rev: "1.20.0"
+      hooks:
+          - id: django-upgrade
+            args: [--target-version, "4.2"]
     - repo: https://github.com/mgedmin/check-manifest
       rev: "0.49"
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
       rev: v3.17.0
       hooks:
           - id: pyupgrade
-            args: [--py36-plus]
+            args: [--py38-plus]
     - repo: https://github.com/mgedmin/check-manifest
       rev: "0.49"
       hooks:

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<3.3
+Django>=4.2,<4.3
 factory-boy==3.3.0
 Faker==26.1.0
 Pygments==2.18.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ from os.path import abspath, join
 import sphinx_rtd_theme  # noqa: F401
 from django import setup as django_setup
 from django.conf import settings as django_settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import strip_tags
 
 sys.path.insert(0, abspath(join("..", "src")))
@@ -53,9 +53,9 @@ def annotate_field(lines, field, models):
 
     if field.help_text:
         # Decode and strip any html out of the field's help text
-        help_text = strip_tags(force_text(field.help_text))
+        help_text = strip_tags(force_str(field.help_text))
     else:
-        help_text = force_text(field.verbose_name).capitalize()
+        help_text = force_str(field.verbose_name).capitalize()
     # Add the model field to the end of the docstring as a param
     # using the verbose name as the description
     lines.append(f":param {field.attname}: {help_text}")
@@ -102,9 +102,9 @@ def process_docstring(app, what, name, obj, options, lines):
             field = form.base_fields[field_name]
             if field.help_text:
                 # Decode and strip any html out of the field's help text
-                help_text = strip_tags(force_text(field.help_text))
+                help_text = strip_tags(force_str(field.help_text))
             else:
-                help_text = force_text(field.label).capitalize()
+                help_text = force_str(field.label).capitalize()
             lines.append(f":param {field_name}: {help_text}")
             if field.widget.is_hidden:
                 lines.append(

--- a/example_extension_project/config/settings.py
+++ b/example_extension_project/config/settings.py
@@ -112,7 +112,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/example_integration_project/config/settings.py
+++ b/example_integration_project/config/settings.py
@@ -118,7 +118,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/example_integration_project/config/urls.py
+++ b/example_integration_project/config/urls.py
@@ -1,12 +1,10 @@
 """Integration project URL Configuration"""
 
 from django.contrib import admin
-from django.urls import re_path
+from django.urls import path, re_path
 from django.views.generic import TemplateView
 
 urlpatterns = [
     re_path(r"^admin/", admin.site.urls),
-    re_path(
-        r"^$", TemplateView.as_view(template_name="home.html"), name="home"
-    ),
+    path("", TemplateView.as_view(template_name="home.html"), name="home"),
 ]

--- a/example_replacement_project/config/settings.py
+++ b/example_replacement_project/config/settings.py
@@ -114,7 +114,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -10,8 +10,8 @@ authors = [
     { name = "Andrew Pinkham" },
 ]
 readme = "README.rst"
-requires-python = ">=3.6"
-dependencies = ["django>=2.2"]
+requires-python = ">=3.8"
+dependencies = ["django>=4.2"]
 license = { file = "LICENSE"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -20,8 +20,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -29,12 +27,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
 ]
 
@@ -87,5 +79,5 @@ exclude = [
 
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py38']
 include = '\.pyi?$'

--- a/src/improved_user/__init__.py
+++ b/src/improved_user/__init__.py
@@ -7,5 +7,4 @@
 # pylint: disable=invalid-name
 __version__ = "2.1.0"
 # https://docs.djangoproject.com/en/stable/ref/applications/#configuring-applications
-default_app_config = "improved_user.apps.ImprovedUserConfig"
 # pylint: enable=invalid-name

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
 isolated_build = True
 envlist =
-	py311-django42-pkgcheck,
+	py312-django42-pkgcheck,
 	py312-docs,
-	py{36,37,38,39}-django{22,30,31}-unit,
-	py{36,37,38,39,310}-django32-unit,
-	py{38,39,310}-django40-unit,
-	py{38,39,310,311}-django41-unit,
 	py{38,39,310,311,312}-django42-unit,
-	py39-django{22,32,42}-{extension,replacement}
+	py312-django42-{extension,replacement}
 
 [testenv]
 changedir =
@@ -19,8 +15,7 @@ changedir =
 skip_install =
 	pkgcheck: true
 extras =
-	{extension,
-	replacement,unit}: factory
+	{extension,replacement,unit}: factory
 setenv =
 	PYTHONDONTWRITEBYTECODE=1
 	{extension,replacement,unit}: PYTHONWARNINGS=once
@@ -29,12 +24,6 @@ deps =
 	docs: -r{toxinidir}/doc-requirements.txt
 	extension: -r{toxinidir}/example_extension_project/requirements.txt
 	replacement: -r{toxinidir}/example_replacement_project/requirements.txt
-	django22: Django>=2.2,<2.3
-	django30: Django>=3.0,<3.1
-	django31: Django>=3.1,<3.2
-	django32: Django>=3.2,<3.3
-	django40: Django>=4.0,<4.1
-	django41: Django>=4.1,<4.2
 	django42: Django>=4.2,<4.3
 commands =
 	docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
In anticipation of django-improved-user v3, which will be compatible with Django 4.2, 5.0, and 5.1, first:

- reduce the test suite to just Django 4.2
  (removing Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1)
- remove compatibility with Python 3.6 and 3.7
- upgrade Ubuntu test suite runners 20.04 → 22.04
- remove deprecated Django features

Note that tests no longer run on the integration example project. This is largely because the project is structured to use django-registration v2, which is not compatible with Django above v2.2. An improved test-suite for the integration material is forthcoming.