### PR TITLE
fix: Support Django 5.2 LTS

### DIFF
--- a/.github/workflows/define-labels.yml
+++ b/.github/workflows/define-labels.yml
@@ -10,7 +10,7 @@ jobs:
     define:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: micnncim/action-label-syncer@v1.3.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,12 +11,12 @@ jobs:
         runs-on: ubuntu-22.04
         environment: publish
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Build sdist
               run: pipx run build --sdist --wheel
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v6
               with:
                   path: dist/*
 
@@ -31,7 +31,7 @@ jobs:
             id-token: write
         steps:
             - name: Download artifact from build step
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: artifact
                   path: dist

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
             - name: Get pip cache dir
               id: pip-cache
-              run: echo "::set-output name=dir::$(pip cache dir)"
+              run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies
               uses: actions/cache@v5

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -26,10 +26,10 @@ jobs:
                 project: ["extension", "replacement"]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.14"
 
@@ -41,7 +41,7 @@ jobs:
               run: echo "::set-output name=dir::$(pip cache dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: ${{ steps.pip-cache.outputs.dir }}
                   key:

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -22,16 +22,24 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
-                django-version: ["5.2"]
+                python-version: ["3.12", "3.14"]
+                django-version: ["4.2", "5.2"]
                 project: ["extension", "replacement"]
+                exclude:
+                    # Django 4.2 only supports Python up to 3.12
+                    - python-version: "3.14"
+                      django-version: "4.2"
+                    # Test Django 5.2 with latest Python only
+                    - python-version: "3.12"
+                      django-version: "5.2"
 
         steps:
             - uses: actions/checkout@v6
 
-            - name: Set up Python
+            - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:
-                  python-version: "3.14"
+                  python-version: ${{ matrix.python-version }}
 
             - name: Upgrade pip
               run: python3 -m pip install -U distlib pip setuptools wheel
@@ -61,8 +69,9 @@ jobs:
 
             - name: Python and Django versions
               run: |
+                  echo "Python ${{ matrix.python-version }} & Django ${{ matrix.django-version }}"
                   python3 --version
-                  echo "Django ${{ matrix.django-version }}: $(django-admin --version)"
+                  echo "Django: $(django-admin --version)"
 
             - name: Run tests
               working-directory: ./example_${{ matrix.project }}_project

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -46,6 +46,7 @@ jobs:
 
             - name: Get pip cache dir
               id: pip-cache
+              shell: bash
               run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies

--- a/.github/workflows/run-project-tests.yml
+++ b/.github/workflows/run-project-tests.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
-                django-version: ["4.2"]
+                django-version: ["5.2"]
                 project: ["extension", "replacement"]
 
         steps:
@@ -31,7 +31,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.12"
+                  python-version: "3.14"
 
             - name: Upgrade pip
               run: python3 -m pip install -U distlib pip setuptools wheel

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,6 +40,7 @@ jobs:
 
             - name: Get pip cache dir
               id: pip-cache
+              shell: bash
               run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,8 +18,13 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
+<<<<<<< HEAD
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
                 django-version: ["4.2"]
+=======
+                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+                django-version: ["5.2"]
+>>>>>>> 1eec7d2 (fixup! ci: Test on Django 5.2 and Python 3.14)
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: Get pip cache dir
               id: pip-cache
-              run: echo "::set-output name=dir::$(pip cache dir)"
+              run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies
               uses: actions/cache@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,8 +18,17 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
-                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-                django-version: ["5.2"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+                django-version: ["4.2", "5.2"]
+                exclude:
+                    # Django 4.2 only supports Python up to 3.12
+                    - python-version: "3.13"
+                      django-version: "4.2"
+                    - python-version: "3.14"
+                      django-version: "4.2"
+                    # Django 5.2 requires Python 3.10+
+                    - python-version: "3.9"
+                      django-version: "5.2"
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,10 +27,10 @@ jobs:
 >>>>>>> 1eec7d2 (fixup! ci: Test on Django 5.2 and Python 3.14)
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -42,7 +42,7 @@ jobs:
               run: echo "::set-output name=dir::$(pip cache dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: ${{ steps.pip-cache.outputs.dir }}
                   key:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,13 +18,8 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
-<<<<<<< HEAD
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-                django-version: ["4.2"]
-=======
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 django-version: ["5.2"]
->>>>>>> 1eec7d2 (fixup! ci: Test on Django 5.2 and Python 3.14)
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, windows-2022]
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 django-version: ["4.2", "5.2"]
                 exclude:
                     # Django 4.2 only supports Python up to 3.12
@@ -26,9 +26,6 @@ jobs:
                       django-version: "4.2"
                     - python-version: "3.14"
                       django-version: "4.2"
-                    # Django 5.2 requires Python 3.10+
-                    - python-version: "3.9"
-                      django-version: "5.2"
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,8 +68,7 @@ jobs:
                   coverage xml
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v5
               with:
-                  token: ${{ secrets.CODECOV_TOKEN }}
                   fail_ci_if_error: true
                   verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: "python3.9"
+    python: "python3.10"
 repos:
     #    - repo: meta
     #      hooks:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ If you're new and want to see what your options are, please read
 :doc:`select_configuration_method`.
 
 The documentation you are viewing covers Django Improved User 2.1,
-compatible with Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.2.
+compatible with Django 4.2 and 5.2 (Python 3.10 to 3.14).
 
 .. toctree::
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ If you're new and want to see what your options are, please read
 :doc:`select_configuration_method`.
 
 The documentation you are viewing covers Django Improved User 2.1,
-compatible with Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2.
+compatible with Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.2.
 
 .. toctree::
    :caption: Contents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Andrew Pinkham" },
 ]
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["django>=4.2"]
 license = { file = "LICENSE"}
 classifiers = [
@@ -20,11 +20,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
@@ -79,5 +79,5 @@ exclude = [
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ['py310']
 include = '\.pyi?$'

--- a/src/improved_user/admin.py
+++ b/src/improved_user/admin.py
@@ -40,3 +40,4 @@ class UserAdmin(BaseUserAdmin):
     list_display = ("email", "full_name", "short_name", "is_staff")
     search_fields = ("email", "full_name", "short_name")
     ordering = ("email",)
+    readonly_fields = ("last_login", "date_joined")

--- a/src/improved_user/managers.py
+++ b/src/improved_user/managers.py
@@ -63,7 +63,8 @@ class UserManager(BaseUserManager):
     ):
         """Generate a random password with the given length and allowed_chars.
 
-        The default value of allowed_chars does not have "I" or "O" or letters
-        and digits that look similar -- just to avoid confusion.
+        The default value of allowed_chars excludes visually ambiguous
+        characters: lowercase 'i', 'l', 'o'; uppercase 'I', 'O'; and
+        digits '0', '1'.
         """
         return get_random_string(length, allowed_chars)

--- a/src/improved_user/managers.py
+++ b/src/improved_user/managers.py
@@ -1,6 +1,7 @@
 """User Manager used by Improved User; may be extended"""
 
 from django.contrib.auth.models import BaseUserManager
+from django.utils.crypto import get_random_string
 
 
 class UserManager(BaseUserManager):
@@ -54,3 +55,15 @@ class UserManager(BaseUserManager):
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
         return self._create_user(email, password, **extra_fields)
+
+    def make_random_password(
+        self,
+        length=10,
+        allowed_chars="abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789",
+    ):
+        """Generate a random password with the given length and allowed_chars.
+
+        The default value of allowed_chars does not have "I" or "O" or letters
+        and digits that look similar -- just to avoid confusion.
+        """
+        return get_random_string(length, allowed_chars)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -55,7 +55,7 @@ class UserAdminTests(TestCase):
 
     def logout(self):
         """Logout the user; helper function"""
-        response = self.client.get("/admin/logout/")
+        response = self.client.post("/admin/logout/")
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(SESSION_KEY, self.client.session)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ isolated_build = True
 envlist =
 	py312-django42-pkgcheck,
 	py312-docs,
-	py{310,311,312,313}-django42-unit,
-	py312-django42-{extension,replacement}
+	py{310,311,312}-django42-unit,
+	py{310,311,312,313,314}-django52-unit,
+	py312-django42-{extension,replacement},
 	py314-django52-{extension,replacement}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 	py312-docs,
 	py{38,39,310,311,312}-django42-unit,
 	py312-django42-{extension,replacement}
+	py314-django52-{extension,replacement}
 
 [testenv]
 changedir =
@@ -25,6 +26,7 @@ deps =
 	extension: -r{toxinidir}/example_extension_project/requirements.txt
 	replacement: -r{toxinidir}/example_replacement_project/requirements.txt
 	django42: Django>=4.2,<4.3
+	django52: Django>=5.2,<6.0
 commands =
 	docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 	docs: python -msphinx -b linkcheck . build/linkcheck

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = True
 envlist =
 	py312-django42-pkgcheck,
 	py312-docs,
-	py{38,39,310,311,312}-django42-unit,
+	py{310,311,312,313}-django42-unit,
 	py312-django42-{extension,replacement}
 	py314-django52-{extension,replacement}
 


### PR DESCRIPTION
- Support Django 5.2 LTS
- Test on Python 3.14 in CI
- Drop support for EOL Python 3.8 & 3.9
- Upgrade GitHub Actions to latest versions