### PR TITLE
🗑 remove make_random_password method

### DIFF
--- a/src/improved_user/managers.py
+++ b/src/improved_user/managers.py
@@ -1,7 +1,6 @@
 """User Manager used by Improved User; may be extended"""
 
 from django.contrib.auth.models import BaseUserManager
-from django.utils.crypto import get_random_string
 
 
 class UserManager(BaseUserManager):
@@ -55,16 +54,3 @@ class UserManager(BaseUserManager):
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
         return self._create_user(email, password, **extra_fields)
-
-    def make_random_password(
-        self,
-        length=10,
-        allowed_chars="abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789",
-    ):
-        """Generate a random password with the given length and allowed_chars.
-
-        The default value of allowed_chars excludes visually ambiguous
-        characters: lowercase 'i', 'l', 'o'; uppercase 'I', 'O'; and
-        digits '0', '1'.
-        """
-        return get_random_string(length, allowed_chars)

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -92,14 +92,6 @@ class UserManagerTestCase(TestCase):
                 is_staff=False,
             )
 
-    def test_make_random_password(self):
-        """Test manager make_random_password method"""
-        allowed_chars = "abcdefg"
-        password = UserManager().make_random_password(5, allowed_chars)
-        self.assertEqual(len(password), 5)
-        for char in password:
-            self.assertIn(char, allowed_chars)
-
     def test_last_login_is_none(self):
         """Check that last login is unset when created
 


### PR DESCRIPTION
Django 5.2 removed make_random_password from BaseUserManager, and upstream guidance is to call django.utils.crypto.get_random_string directly. Drop the local override and its test so the project follows upstream behavior.

Related to commit ba89888c17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an internal helper method and its corresponding test from the user management module. Core user and superuser creation functionality remains intact and unaffected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jambonrose/django-improved-user/pull/329)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->